### PR TITLE
chore: suppress auto-updates for recently released npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages:
   - "packages/*"
+
+minimumReleaseAge: 4320 # 3d


### PR DESCRIPTION
## Summary

リリース直後の不安定な npm パッケージへの自動更新を抑制する設定を追加。

- `pnpm-workspace.yaml` に `minimumReleaseAge: 4320`（3日）を追加
- `dependabot.yml` の npm 更新に `cooldown.default-days: 3` を追加
