### PR TITLE
ci: add cooldown to dependabot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

- dependabot の npm 更新に `cooldown.default-days: 3` を追加
- リリース直後の不安定なパッケージへの自動更新を抑制する
