### PR TITLE
feat(next-typed-href): defineTypedHrefWithNuqs で withDefault パーサーをサポート

### DIFF
--- a/.changeset/nuqs-with-default-support.md
+++ b/.changeset/nuqs-with-default-support.md
@@ -1,0 +1,5 @@
+---
+"@plainbrew/next-typed-href": patch
+---
+
+fix: Support withDefault parsers in defineTypedHrefWithNuqs; null is now a type error for non-nullable params, and values equal to the default are omitted from the URL

--- a/.changeset/nuqs-with-default-support.md
+++ b/.changeset/nuqs-with-default-support.md
@@ -1,5 +1,5 @@
 ---
-"@plainbrew/next-typed-href": patch
+"@plainbrew/next-typed-href": minor
 ---
 
 fix: Support withDefault parsers in defineTypedHrefWithNuqs; null is now a type error for non-nullable params, and values equal to the default are omitted from the URL

--- a/packages/next-typed-href/README.md
+++ b/packages/next-typed-href/README.md
@@ -111,9 +111,36 @@ $href({ route: "/users/[id]", routeParams: { id: "42" }, searchParams: { tab: "p
 // => "/users/42?tab=profile"
 ```
 
+### `withDefault` pattern
+
+Parsers wrapped with `.withDefault()` make the type non-nullable and omit the key from the URL when the value equals the default:
+
+```ts
+export const { $href } = defineTypedHrefWithNuqs<AppRoutes, AppRouteParamsMap>()({
+  "/search": {
+    q: parseAsString.withDefault(""),
+    page: parseAsInteger.withDefault(1),
+  },
+});
+
+// Value differs from default → included
+$href({ route: "/search", searchParams: { q: "hello", page: 2 } });
+// => "/search?q=hello&page=2"
+
+// Value equals default → omitted (consistent with nuqs URL semantics)
+$href({ route: "/search", searchParams: { q: "hello", page: 1 } });
+// => "/search?q=hello"
+
+// null is a type error for withDefault params
+$href({ route: "/search", searchParams: { q: null } });
+// => TypeError: Type 'null' is not assignable to type 'string | undefined'
+```
+
 ### nuqs integration notes
 
 - `null` and `undefined` values are omitted from the query string.
-- Values are serialized using the nuqs parser's `serialize` method.
+- Values are serialized using nuqs' `createSerializer`, which respects `withDefault` behavior.
+- When a `withDefault` param value equals the default, the key is cleared from the URL.
+- `null` is a type error for `withDefault` params (the type is non-nullable).
 - Routes without a parser defined fall back to standard `URLSearchParams` behavior.
 - `nuqs` is a peer dependency and is optional for projects not using this entry point.

--- a/packages/next-typed-href/src/nuqs.test.ts
+++ b/packages/next-typed-href/src/nuqs.test.ts
@@ -117,7 +117,7 @@ describe("dynamic segments work with nuqs searchParams", () => {
   });
 });
 
-describe("withDefault パターン", () => {
+describe("withDefault pattern", () => {
   const { $href: $hrefWD } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
     "/search": {
       q: parseAsString.withDefault(""),
@@ -125,44 +125,44 @@ describe("withDefault パターン", () => {
     },
   });
 
-  test("withDefault 付きの string パラメータをシリアライズする", () => {
+  test("serializes string param with withDefault", () => {
     expect($hrefWD({ route: "/search", searchParams: { q: "hello" } })).toBe("/search?q=hello");
   });
 
-  test("withDefault 付きの integer パラメータをシリアライズする", () => {
+  test("serializes integer param with withDefault", () => {
     expect($hrefWD({ route: "/search", searchParams: { page: 2 } })).toBe("/search?page=2");
   });
 
-  test("複数の withDefault パラメータをシリアライズする", () => {
+  test("serializes multiple withDefault params", () => {
     expect($hrefWD({ route: "/search", searchParams: { q: "next", page: 3 } })).toBe(
       "/search?q=next&page=3",
     );
   });
 
-  test("withDefault パラメータで undefined を渡すとスキップされる", () => {
+  test("skips undefined values for withDefault params", () => {
     expect($hrefWD({ route: "/search", searchParams: { q: "hello", page: undefined } })).toBe(
       "/search?q=hello",
     );
   });
 
-  test("デフォルト値と同じ値を渡すとパラメータが省略される", () => {
+  test("omits param when value equals default", () => {
     expect($hrefWD({ route: "/search", searchParams: { page: 1 } })).toBe("/search");
   });
 
-  test("デフォルト値と異なる値のみシリアライズされる", () => {
+  test("omits default-value params while keeping non-default ones", () => {
     expect($hrefWD({ route: "/search", searchParams: { q: "hello", page: 1 } })).toBe(
       "/search?q=hello",
     );
   });
 
-  test("型エラー: withDefault パラメータに null は渡せない", () => {
-    // @ts-expect-error: withDefault により型が非 nullable になるため null は不可
+  test("rejects null for withDefault param (type error)", () => {
+    // @ts-expect-error: withDefault makes the type non-nullable, null is not allowed
     $hrefWD({ route: "/search", searchParams: { q: null } });
   });
 });
 
-describe("withDefault + 動的セグメント", () => {
-  test("ルートパラメータを解決し、withDefault 付き searchParams を付与する", () => {
+describe("withDefault with dynamic segments", () => {
+  test("resolves route params and adds withDefault searchParams", () => {
     const { $href: $hrefUserWD } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
       "/users/[id]": { tab: parseAsString.withDefault("profile") },
     });

--- a/packages/next-typed-href/src/nuqs.test.ts
+++ b/packages/next-typed-href/src/nuqs.test.ts
@@ -145,6 +145,16 @@ describe("withDefault パターン", () => {
     );
   });
 
+  test("デフォルト値と同じ値を渡すとパラメータが省略される", () => {
+    expect($hrefWD({ route: "/search", searchParams: { page: 1 } })).toBe("/search");
+  });
+
+  test("デフォルト値と異なる値のみシリアライズされる", () => {
+    expect($hrefWD({ route: "/search", searchParams: { q: "hello", page: 1 } })).toBe(
+      "/search?q=hello",
+    );
+  });
+
   test("型エラー: withDefault パラメータに null は渡せない", () => {
     // @ts-expect-error: withDefault により型が非 nullable になるため null は不可
     $hrefWD({ route: "/search", searchParams: { q: null } });

--- a/packages/next-typed-href/src/nuqs.test.ts
+++ b/packages/next-typed-href/src/nuqs.test.ts
@@ -116,3 +116,53 @@ describe("dynamic segments work with nuqs searchParams", () => {
     ).toBe("/users/42?tab=profile");
   });
 });
+
+describe("withDefault パターン", () => {
+  const { $href: $hrefWD } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
+    "/search": {
+      q: parseAsString.withDefault(""),
+      page: parseAsInteger.withDefault(1),
+    },
+  });
+
+  test("withDefault 付きの string パラメータをシリアライズする", () => {
+    expect($hrefWD({ route: "/search", searchParams: { q: "hello" } })).toBe("/search?q=hello");
+  });
+
+  test("withDefault 付きの integer パラメータをシリアライズする", () => {
+    expect($hrefWD({ route: "/search", searchParams: { page: 2 } })).toBe("/search?page=2");
+  });
+
+  test("複数の withDefault パラメータをシリアライズする", () => {
+    expect($hrefWD({ route: "/search", searchParams: { q: "next", page: 3 } })).toBe(
+      "/search?q=next&page=3",
+    );
+  });
+
+  test("withDefault パラメータで undefined を渡すとスキップされる", () => {
+    expect($hrefWD({ route: "/search", searchParams: { q: "hello", page: undefined } })).toBe(
+      "/search?q=hello",
+    );
+  });
+
+  test("型エラー: withDefault パラメータに null は渡せない", () => {
+    // @ts-expect-error: withDefault により型が非 nullable になるため null は不可
+    $hrefWD({ route: "/search", searchParams: { q: null } });
+  });
+});
+
+describe("withDefault + 動的セグメント", () => {
+  test("ルートパラメータを解決し、withDefault 付き searchParams を付与する", () => {
+    const { $href: $hrefUserWD } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
+      "/users/[id]": { tab: parseAsString.withDefault("profile") },
+    });
+
+    expect(
+      $hrefUserWD({
+        route: "/users/[id]",
+        routeParams: { id: "42" },
+        searchParams: { tab: "settings" },
+      }),
+    ).toBe("/users/42?tab=settings");
+  });
+});

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -1,5 +1,5 @@
-import { createSerializer } from "nuqs";
 import type { inferParserType, SingleParserBuilder } from "nuqs";
+import { createSerializer } from "nuqs/server";
 
 import { generatePath } from "./common/generatePath";
 

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -1,3 +1,4 @@
+import { createSerializer } from "nuqs";
 import type { inferParserType, SingleParserBuilder } from "nuqs";
 
 import { generatePath } from "./common/generatePath";
@@ -41,20 +42,6 @@ type PathOptionsFor<
       }
   : never;
 
-function serializeNuqsSearchParams(
-  values: Record<string, unknown>,
-  parsers: Record<string, AnyParserBuilder>,
-): string {
-  const entries: [string, string][] = [];
-  for (const [key, value] of Object.entries(values)) {
-    if (value === null || value === undefined) continue;
-    const parser = parsers[key];
-    const serialized = parser ? parser.serialize(value) : String(value);
-    entries.push([key, serialized]);
-  }
-  return entries.length > 0 ? `?${new URLSearchParams(entries).toString()}` : "";
-}
-
 /**
  * Type-safe href generator for Next.js App Router with nuqs integration.
  *
@@ -91,10 +78,7 @@ export function defineTypedHrefWithNuqs<
 
       if (options.searchParams != null) {
         if (routeParsers) {
-          search = serializeNuqsSearchParams(
-            options.searchParams as Record<string, unknown>,
-            routeParsers,
-          );
+          search = createSerializer(routeParsers)(options.searchParams as Record<string, unknown>);
         } else {
           const sp = new URLSearchParams(
             options.searchParams as ConstructorParameters<typeof URLSearchParams>[0],

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -9,7 +9,7 @@ type NuqsParsersMap<Routes extends string> = Partial<
 >;
 
 type ParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
-  [K in keyof Parsers]?: inferParserType<Parsers[K]> | null;
+  [K in keyof Parsers]?: inferParserType<Parsers[K]>;
 };
 
 type SearchParamsFor<T extends string, NuqsMap extends NuqsParsersMap<T>> =


### PR DESCRIPTION
## 概要

fix  https://linear.app/plainbrew/issue/PC-62

- `nuqs` の `withDefault` を使ったパーサーパターンのテストを追加
- `ParserValues` 型から余分な `| null` を除去し、`withDefault` パーサーで `null` を渡すと型エラーになるよう修正

## 変更内容

### `nuqs.ts`

`ParserValues` の `| null` を削除。`inferParserType` が `withDefault` なしのパーサーでは `T | null`、`withDefault` ありでは `T` を返すため、追加の `| null` は不要かつ `withDefault` の型制約を壊していた。

### `nuqs.test.ts`

- `withDefault` パターンのシリアライズテスト（string / integer / 複数パラメータ / undefined スキップ）
- `withDefault` パラメータに `null` を渡すと型エラーになることの確認（`@ts-expect-error`）
- `withDefault` + 動的セグメントの組み合わせテスト




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `withDefault` パーサーをサポートしました。デフォルト値が設定された検索パラメータは、指定値と等しい場合に生成されるURLから省略されます。

* **動作変更**
  * 検索パラメータのシリアライズが既定のシリアライザ方式に合わせて扱われます。
  * `undefined` は出力から省略されます。

* **バグ修正**
  * 非nullable なパラメータに対して `null` を渡すと型エラーとなるよう改善しました。

* **ドキュメント**
  * `withDefault` の使用例と型挙動、既定値等しい場合の省略について README を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->