### PR TITLE
refactor(next-typed-href): move type aliases into defineTypedHrefWithNuqs closure

### DIFF
--- a/.changeset/nuqs-move-types-into-closure.md
+++ b/.changeset/nuqs-move-types-into-closure.md
@@ -1,0 +1,5 @@
+---
+"@plainbrew/next-typed-href": patch
+---
+
+refactor: move RouteHasParams/SearchParamsFor/PathOptionsFor types inside defineTypedHrefWithNuqs closure

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -13,35 +13,6 @@ type ParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
   [K in keyof Parsers]?: inferParserType<Parsers[K]>;
 };
 
-type SearchParamsFor<T extends string, NuqsMap extends NuqsParsersMap<T>> =
-  NuqsMap[T] extends Record<string, AnyParserBuilder>
-    ? ParserValues<NuqsMap[T]>
-    : ConstructorParameters<typeof URLSearchParams>[0];
-
-type RouteHasParams<
-  T extends string,
-  RouteParamsMap extends Record<string, Record<string, unknown>>,
-> = RouteParamsMap[T] extends Record<string, never> ? false : true;
-
-type PathOptionsFor<
-  T extends string,
-  RouteParamsMap extends Record<string, Record<string, unknown>>,
-  NuqsMap extends NuqsParsersMap<string>,
-> = T extends string
-  ? RouteHasParams<T, RouteParamsMap> extends true
-    ? {
-        route: T;
-        routeParams: RouteParamsMap[T];
-        searchParams?: SearchParamsFor<T, NuqsMap>;
-        hash?: string;
-      }
-    : {
-        route: T;
-        searchParams?: SearchParamsFor<T, NuqsMap>;
-        hash?: string;
-      }
-  : never;
-
 /**
  * Type-safe href generator for Next.js App Router with nuqs integration.
  *
@@ -63,8 +34,31 @@ export function defineTypedHrefWithNuqs<
   Routes extends string,
   RouteParamsMap extends Record<Routes, Record<string, unknown>>,
 >() {
+  type RouteHasParams<T extends Routes> =
+    RouteParamsMap[T] extends Record<string, never> ? false : true;
+
   return function <NuqsMap extends NuqsParsersMap<Routes>>(nuqsMap: NuqsMap) {
-    function $href<T extends Routes>(options: PathOptionsFor<T, RouteParamsMap, NuqsMap>): string {
+    type SearchParamsFor<T extends Routes> =
+      NuqsMap[T] extends Record<string, AnyParserBuilder>
+        ? ParserValues<NuqsMap[T]>
+        : ConstructorParameters<typeof URLSearchParams>[0];
+
+    type PathOptionsFor<T extends Routes> = T extends Routes
+      ? RouteHasParams<T> extends true
+        ? {
+            route: T;
+            routeParams: RouteParamsMap[T];
+            searchParams?: SearchParamsFor<T>;
+            hash?: string;
+          }
+        : {
+            route: T;
+            searchParams?: SearchParamsFor<T>;
+            hash?: string;
+          }
+      : never;
+
+    function $href<T extends Routes>(options: PathOptionsFor<T>): string {
       const path =
         "routeParams" in options
           ? generatePath(


### PR DESCRIPTION
## 概要

fix https://linear.app/plainbrew/issue/PC-63

`packages/next-typed-href/src/nuqs.ts` のトップレベル型エイリアスを `defineTypedHrefWithNuqs` のクロージャ内に移動。

- `RouteHasParams` → 外側クロージャ（`Routes`/`RouteParamsMap` をキャプチャ）
- `SearchParamsFor` / `PathOptionsFor` → 内側クロージャ（`NuqsMap` もキャプチャ）

`index.ts` の `defineTypedHref` と同じ構造に統一し、各型の型パラメータを削減。

## 参考

- [PR #28 レビューコメント](https://github.com/plainbrew/next-utils/pull/28#discussion_r3114732691)
