### PR TITLE
docs: document curried pattern and named factory usage in defineTypedHrefWithNuqs

### DIFF
--- a/.changeset/teal-cups-swim.md
+++ b/.changeset/teal-cups-swim.md
@@ -1,0 +1,5 @@
+---
+"@plainbrew/next-typed-href": patch
+---
+
+docs: document named factory pattern and reason for curried design in defineTypedHrefWithNuqs

--- a/packages/next-typed-href/README.md
+++ b/packages/next-typed-href/README.md
@@ -81,7 +81,9 @@ import type { AppRoutes, ParamsOf } from "@/../.next/types/routes";
 
 type AppRouteParamsMap = { [Route in AppRoutes]: ParamsOf<Route> };
 
-export const { $href } = defineTypedHrefWithNuqs<AppRoutes, AppRouteParamsMap>()({
+const withNuqs = defineTypedHrefWithNuqs<AppRoutes, AppRouteParamsMap>();
+
+export const { $href } = withNuqs({
   "/search": {
     q: parseAsString,
     page: parseAsInteger,
@@ -116,7 +118,9 @@ $href({ route: "/users/[id]", routeParams: { id: "42" }, searchParams: { tab: "p
 Parsers wrapped with `.withDefault()` make the type non-nullable and omit the key from the URL when the value equals the default:
 
 ```ts
-export const { $href } = defineTypedHrefWithNuqs<AppRoutes, AppRouteParamsMap>()({
+const withNuqs = defineTypedHrefWithNuqs<AppRoutes, AppRouteParamsMap>();
+
+export const { $href } = withNuqs({
   "/search": {
     q: parseAsString.withDefault(""),
     page: parseAsInteger.withDefault(1),

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -19,8 +19,15 @@ type ParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
  * Routes that have nuqs parsers defined accept typed searchParams values.
  * Routes without parsers fall back to standard URLSearchParams input.
  *
+ * The function is curried — call it once with explicit type parameters to get
+ * a route-specific factory, then call that factory with your parsers map.
+ * TypeScript cannot infer the third type parameter alongside explicit ones
+ * (microsoft/TypeScript#26242), so the two-step form is required.
+ *
  * @example
- * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
+ * // Recommended: store the factory and call it once
+ * const withNuqs = defineTypedHrefWithNuqs<Routes, RouteParamsMap>();
+ * const { $href } = withNuqs({
  *   "/search": { q: parseAsString, page: parseAsInteger },
  * });
  *


### PR DESCRIPTION
## Summary

`defineTypedHrefWithNuqs` の `()({...})` という二重呼び出し構文が気になるという指摘を受け、シングルコール `<Routes, RouteParamsMap>(nuqsMap)` に変更できないか調査した。

**調査結果：** TypeScript は明示的な型引数と残りの型引数の推論を同時に行えない（Partial Type Argument Inference が未実装 / [microsoft/TypeScript#26242](https://github.com/microsoft/TypeScript/issues/26242)）。TypeScript 5.9 でも確認済み。

以下のアプローチをすべて試したが、`NuqsMap` が引数から推論されずデフォルト型が使われた：
- デフォルト付き型パラメータ `NuqsMap = NuqsParsersMap<Routes>`
- `const` 型パラメータ（TypeScript 5.0）
- オーバーロード
- `object` を制約にした intersection `NuqsMap & NuqsParsersMap<Routes>`
- クロージャ経由

**対応：** カリー化の設計意図と、`()({...})` を避けた Named Factory パターンを JSDoc に明記した。

```ts
// Recommended
const withNuqs = defineTypedHrefWithNuqs<Routes, RouteParamsMap>();
const { $href } = withNuqs({ "/search": { q: parseAsString } });
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * nuqs 統合の使用例を、段階的に呼び出すパターン（ファクトリを取得してから構成を渡す）に合わせて分かりやすく更新しました。README の例とパターン説明を整理しています。
* **雑務**
  * パッケージ用の変更履歴エントリを追加し、次のパッチリリース向けにドキュメント変更を記録しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->