### PR TITLE
revert: TypeScript 6 へのアップグレードを revert (tsup が非対応のため)

### DIFF
--- a/packages/next-typed-href/package.json
+++ b/packages/next-typed-href/package.json
@@ -44,7 +44,7 @@
     "@types/node": "^22.19.17",
     "nuqs": "^2.8.9",
     "tsup": "^8.0.0",
-    "typescript": "^6.0.3",
+    "typescript": "^5.0.0",
     "vitest": "^4.1.4"
   },
   "peerDependencies": {

--- a/packages/vercel-basic-auth/package.json
+++ b/packages/vercel-basic-auth/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/node": "^22.19.17",
     "tsup": "^8.0.0",
-    "typescript": "^6.0.3",
+    "typescript": "^5.0.0",
     "vitest": "^4.1.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,10 +37,10 @@ importers:
         version: 2.8.9(react@19.2.5)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.10)(typescript@6.0.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^5.0.0
+        version: 5.9.3
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@22.19.17)(vite@8.0.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.8.3))
@@ -52,10 +52,10 @@ importers:
         version: 22.19.17
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.10)(typescript@6.0.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^5.0.0
+        version: 5.9.3
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@22.19.17)(vite@8.0.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.8.3))
@@ -1508,8 +1508,8 @@ packages:
       typescript:
         optional: true
 
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2865,7 +2865,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(postcss@8.5.10)(typescript@6.0.3)(yaml@2.8.3):
+  tsup@8.5.1(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -2886,14 +2886,14 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.10
-      typescript: 6.0.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
       - supports-color
       - tsx
       - yaml
 
-  typescript@6.0.3: {}
+  typescript@5.9.3: {}
 
   ufo@1.6.3: {}
 


### PR DESCRIPTION
## 概要

TypeScript 6.0.3 へのアップグレード (#42) を revert します。

tsup が TypeScript 6 に非対応のため、5.x に戻します。

https://github.com/egoist/tsup/issues/1389

## 関連

- Reverts #42
