### PR TITLE
chore: add CLAUDE.md with Linear project info

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+## Linear
+
+- Workspace: `plainbrew`
+- Team: `Plainbrew Common` (key: `PC`)
+- Project: `next-utils` (id: `d73600a1-be01-43ce-83fb-8b710924b8c5`)


### PR DESCRIPTION
## Summary

- `CLAUDE.md` を追加し、Linear のワークスペース・チーム・プロジェクト情報を記載
- [chat-adapter-backlog の CLAUDE.md](https://github.com/plainbrew/chat-adapter-backlog/blob/main/CLAUDE.md) と同じ形式
