### PR TITLE
fix(example): wrap useQueryStates in Suspense boundary on search page

### DIFF
--- a/examples/example-next-typed-href-nuqs/src/app/search/page.tsx
+++ b/examples/example-next-typed-href-nuqs/src/app/search/page.tsx
@@ -2,18 +2,17 @@
 
 import Link from "next/link";
 import { useQueryStates } from "nuqs";
+import { Suspense } from "react";
 
 import { $href } from "@/lib/href";
 
 import { searchParams } from "./searchParams";
 
-export default function SearchPage() {
+function SearchContent() {
   const [{ q, page }, setParams] = useQueryStates(searchParams);
 
   return (
-    <main>
-      <h1>Search</h1>
-
+    <>
       <div>
         <input
           type="text"
@@ -35,6 +34,18 @@ export default function SearchPage() {
         )}{" "}
         <Link href={$href({ route: "/search", searchParams: { q, page: page + 1 } })}>Next →</Link>
       </nav>
+    </>
+  );
+}
+
+export default function SearchPage() {
+  return (
+    <main>
+      <h1>Search</h1>
+
+      <Suspense>
+        <SearchContent />
+      </Suspense>
 
       <p>
         <Link href={$href({ route: "/" })}>← Back to home</Link>


### PR DESCRIPTION
## Summary

https://github.com/plainbrew/next-utils/actions/runs/24787453806 でエラーが発生するため

- `/search` ページで `useQueryStates`（内部で `useSearchParams()` を使用）が Suspense バウンダリなしで呼ばれており、Next.js のビルドが失敗していた
- `SearchContent` コンポーネントに分離し、`<Suspense>` で囲むことで修正

参考: https://nuqs.dev/docs/troubleshooting#client-components-need-to-be-wrapped-in-a-suspense-boundary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクター**
  * 検索ページの構造を最適化し、読み込みパフォーマンスを向上させました。ページの安定性と応答性が改善されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->