### PR TITLE
feat(next-typed-href): add requiredSearchParams option

### DIFF
--- a/.changeset/nuqs-required-search-params.md
+++ b/.changeset/nuqs-required-search-params.md
@@ -1,5 +1,5 @@
 ---
-"@plainbrew/next-typed-href": major
+"@plainbrew/next-typed-href": minor
 ---
 
 feat(nuqs): add `requiredSearchParams` option to `defineTypedHrefWithNuqs`

--- a/.changeset/nuqs-required-search-params.md
+++ b/.changeset/nuqs-required-search-params.md
@@ -1,0 +1,39 @@
+---
+"@plainbrew/next-typed-href": major
+---
+
+feat(nuqs): add `requiredSearchParams` option to `defineTypedHrefWithNuqs`
+
+### Breaking change
+
+`defineTypedHrefWithNuqs` is now a 3-level curried function. An options call has been inserted as the second level:
+
+```ts
+// before
+defineTypedHrefWithNuqs<Routes, RouteParamsMap>()(nuqsMap);
+
+// after
+defineTypedHrefWithNuqs<Routes, RouteParamsMap>()()(nuqsMap);
+```
+
+### New feature
+
+Pass `{ requiredSearchParams: true }` in the second call to enforce that `searchParams` is provided for routes with nuqs parsers defined.
+
+Fields without `.withDefault()` become required; fields with `.withDefault()` remain optional.
+
+```ts
+const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({ requiredSearchParams: true })(
+  {
+    "/search": {
+      q: parseAsString, // required
+      page: parseAsInteger.withDefault(1), // optional
+    },
+  },
+);
+
+$href({ route: "/search", searchParams: { q: "hello" } }); // OK
+$href({ route: "/search", searchParams: { q: "hello", page: 2 } }); // OK
+$href({ route: "/search" }); // Type error
+$href({ route: "/search", searchParams: { page: 2 } }); // Type error
+```

--- a/examples/example-next-typed-href-nuqs/src/lib/href.ts
+++ b/examples/example-next-typed-href-nuqs/src/lib/href.ts
@@ -5,6 +5,6 @@ import { searchParams as searchSearchParams } from "@/app/search/searchParams";
 
 type AppRouteParamsMap = { [Route in AppRoutes]: ParamsOf<Route> };
 
-export const { $href } = defineTypedHrefWithNuqs<AppRoutes, AppRouteParamsMap>()({
+export const { $href } = defineTypedHrefWithNuqs<AppRoutes, AppRouteParamsMap>()()({
   "/search": searchSearchParams,
 });

--- a/packages/next-typed-href/src/nuqs.test.ts
+++ b/packages/next-typed-href/src/nuqs.test.ts
@@ -178,25 +178,25 @@ describe("withDefault with dynamic segments", () => {
 });
 
 describe("requireSearchParams option", () => {
+  // q: no withDefault → required, page: withDefault → optional
   const { $href: $hrefReq } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
     requireSearchParams: true,
   })({
-    "/search": { q: parseAsString, page: parseAsInteger },
+    "/search": { q: parseAsString, page: parseAsInteger.withDefault(1) },
   });
 
-  test("accepts all required fields", () => {
+  test("accepts required field only (withDefault field omitted)", () => {
+    expect($hrefReq({ route: "/search", searchParams: { q: "hello" } })).toBe("/search?q=hello");
+  });
+
+  test("accepts both fields", () => {
     expect($hrefReq({ route: "/search", searchParams: { q: "hello", page: 2 } })).toBe(
       "/search?q=hello&page=2",
     );
   });
 
-  test("accepts null for required fields (omits from URL)", () => {
-    expect($hrefReq({ route: "/search", searchParams: { q: null, page: 2 } })).toBe(
-      "/search?page=2",
-    );
-    expect($hrefReq({ route: "/search", searchParams: { q: "hello", page: null } })).toBe(
-      "/search?q=hello",
-    );
+  test("accepts null for required field (omits from URL)", () => {
+    expect($hrefReq({ route: "/search", searchParams: { q: null } })).toBe("/search");
   });
 
   test("non-nuqs routes still have optional searchParams", () => {
@@ -204,44 +204,13 @@ describe("requireSearchParams option", () => {
     expect($hrefReq({ route: "/posts", searchParams: { page: "1" } })).toBe("/posts?page=1");
   });
 
-  test("rejects missing searchParams object for nuqs routes (type error)", () => {
+  test("rejects missing searchParams object (type error)", () => {
     // @ts-expect-error: searchParams is required when requireSearchParams: true and parsers are defined
     $hrefReq({ route: "/search" });
   });
 
   test("rejects missing required field (type error)", () => {
-    // @ts-expect-error: page is required (no withDefault)
-    $hrefReq({ route: "/search", searchParams: { q: "hello" } });
-  });
-});
-
-describe("requireSearchParams with withDefault fields", () => {
-  const { $href: $hrefReqWD } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
-    requireSearchParams: true,
-  })({
-    "/search": {
-      q: parseAsString,
-      page: parseAsInteger.withDefault(1),
-    },
-  });
-
-  test("withDefault fields are optional", () => {
-    expect($hrefReqWD({ route: "/search", searchParams: { q: "hello" } })).toBe("/search?q=hello");
-  });
-
-  test("can still pass withDefault fields", () => {
-    expect($hrefReqWD({ route: "/search", searchParams: { q: "hello", page: 2 } })).toBe(
-      "/search?q=hello&page=2",
-    );
-  });
-
-  test("rejects missing non-default field (type error)", () => {
     // @ts-expect-error: q has no withDefault, so it is required
-    $hrefReqWD({ route: "/search", searchParams: { page: 2 } });
-  });
-
-  test("rejects missing searchParams entirely (type error)", () => {
-    // @ts-expect-error: searchParams is required
-    $hrefReqWD({ route: "/search" });
+    $hrefReq({ route: "/search", searchParams: { page: 2 } });
   });
 });

--- a/packages/next-typed-href/src/nuqs.test.ts
+++ b/packages/next-typed-href/src/nuqs.test.ts
@@ -184,8 +184,19 @@ describe("requireSearchParams option", () => {
     "/search": { q: parseAsString, page: parseAsInteger },
   });
 
-  test("accepts required searchParams", () => {
-    expect($hrefReq({ route: "/search", searchParams: { q: "hello" } })).toBe("/search?q=hello");
+  test("accepts all required fields", () => {
+    expect($hrefReq({ route: "/search", searchParams: { q: "hello", page: 2 } })).toBe(
+      "/search?q=hello&page=2",
+    );
+  });
+
+  test("accepts null for required fields (omits from URL)", () => {
+    expect($hrefReq({ route: "/search", searchParams: { q: null, page: 2 } })).toBe(
+      "/search?page=2",
+    );
+    expect($hrefReq({ route: "/search", searchParams: { q: "hello", page: null } })).toBe(
+      "/search?q=hello",
+    );
   });
 
   test("non-nuqs routes still have optional searchParams", () => {
@@ -193,8 +204,44 @@ describe("requireSearchParams option", () => {
     expect($hrefReq({ route: "/posts", searchParams: { page: "1" } })).toBe("/posts?page=1");
   });
 
-  test("rejects missing searchParams for nuqs routes (type error)", () => {
+  test("rejects missing searchParams object for nuqs routes (type error)", () => {
     // @ts-expect-error: searchParams is required when requireSearchParams: true and parsers are defined
     $hrefReq({ route: "/search" });
+  });
+
+  test("rejects missing required field (type error)", () => {
+    // @ts-expect-error: page is required (no withDefault)
+    $hrefReq({ route: "/search", searchParams: { q: "hello" } });
+  });
+});
+
+describe("requireSearchParams with withDefault fields", () => {
+  const { $href: $hrefReqWD } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
+    requireSearchParams: true,
+  })({
+    "/search": {
+      q: parseAsString,
+      page: parseAsInteger.withDefault(1),
+    },
+  });
+
+  test("withDefault fields are optional", () => {
+    expect($hrefReqWD({ route: "/search", searchParams: { q: "hello" } })).toBe("/search?q=hello");
+  });
+
+  test("can still pass withDefault fields", () => {
+    expect($hrefReqWD({ route: "/search", searchParams: { q: "hello", page: 2 } })).toBe(
+      "/search?q=hello&page=2",
+    );
+  });
+
+  test("rejects missing non-default field (type error)", () => {
+    // @ts-expect-error: q has no withDefault, so it is required
+    $hrefReqWD({ route: "/search", searchParams: { page: 2 } });
+  });
+
+  test("rejects missing searchParams entirely (type error)", () => {
+    // @ts-expect-error: searchParams is required
+    $hrefReqWD({ route: "/search" });
   });
 });

--- a/packages/next-typed-href/src/nuqs.test.ts
+++ b/packages/next-typed-href/src/nuqs.test.ts
@@ -12,7 +12,7 @@ type RouteParamsMap = {
   "/posts": Record<string, never>;
 };
 
-const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
+const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()()({
   "/search": {
     q: parseAsString,
     page: parseAsInteger,
@@ -103,7 +103,7 @@ describe("type errors on wrong param types", () => {
 
 describe("dynamic segments work with nuqs searchParams", () => {
   test("resolves route params and adds nuqs-typed searchParams", () => {
-    const { $href: $hrefWithUser } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
+    const { $href: $hrefWithUser } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()()({
       "/users/[id]": { tab: parseAsString },
     });
 
@@ -118,7 +118,7 @@ describe("dynamic segments work with nuqs searchParams", () => {
 });
 
 describe("withDefault pattern", () => {
-  const { $href: $hrefWD } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
+  const { $href: $hrefWD } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()()({
     "/search": {
       q: parseAsString.withDefault(""),
       page: parseAsInteger.withDefault(1),
@@ -163,7 +163,7 @@ describe("withDefault pattern", () => {
 
 describe("withDefault with dynamic segments", () => {
   test("resolves route params and adds withDefault searchParams", () => {
-    const { $href: $hrefUserWD } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
+    const { $href: $hrefUserWD } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()()({
       "/users/[id]": { tab: parseAsString.withDefault("profile") },
     });
 
@@ -174,5 +174,27 @@ describe("withDefault with dynamic segments", () => {
         searchParams: { tab: "settings" },
       }),
     ).toBe("/users/42?tab=settings");
+  });
+});
+
+describe("requireSearchParams option", () => {
+  const { $href: $hrefReq } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
+    requireSearchParams: true,
+  })({
+    "/search": { q: parseAsString, page: parseAsInteger },
+  });
+
+  test("accepts required searchParams", () => {
+    expect($hrefReq({ route: "/search", searchParams: { q: "hello" } })).toBe("/search?q=hello");
+  });
+
+  test("non-nuqs routes still have optional searchParams", () => {
+    expect($hrefReq({ route: "/posts" })).toBe("/posts");
+    expect($hrefReq({ route: "/posts", searchParams: { page: "1" } })).toBe("/posts?page=1");
+  });
+
+  test("rejects missing searchParams for nuqs routes (type error)", () => {
+    // @ts-expect-error: searchParams is required when requireSearchParams: true and parsers are defined
+    $hrefReq({ route: "/search" });
   });
 });

--- a/packages/next-typed-href/src/nuqs.test.ts
+++ b/packages/next-typed-href/src/nuqs.test.ts
@@ -177,10 +177,10 @@ describe("withDefault with dynamic segments", () => {
   });
 });
 
-describe("requireSearchParams option", () => {
+describe("requiredSearchParams option", () => {
   // q: no withDefault → required, page: withDefault → optional
   const { $href: $hrefReq } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
-    requireSearchParams: true,
+    requiredSearchParams: true,
   })({
     "/search": { q: parseAsString, page: parseAsInteger.withDefault(1) },
   });
@@ -205,7 +205,7 @@ describe("requireSearchParams option", () => {
   });
 
   test("rejects missing searchParams object (type error)", () => {
-    // @ts-expect-error: searchParams is required when requireSearchParams: true and parsers are defined
+    // @ts-expect-error: searchParams is required when requiredSearchParams: true and parsers are defined
     $hrefReq({ route: "/search" });
   });
 

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -13,78 +13,123 @@ type ParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
   [K in keyof Parsers]?: inferParserType<Parsers[K]>;
 };
 
+export type DefineTypedHrefWithNuqsOptions = {
+  requireSearchParams?: boolean;
+};
+
+type RouteHasParams<
+  T extends string,
+  RouteParamsMap extends Record<string, Record<string, unknown>>,
+> = RouteParamsMap[T] extends Record<string, never> ? false : true;
+
+type SearchParamsFor<T extends string, NuqsMap extends NuqsParsersMap<string>> =
+  NuqsMap[T] extends Record<string, AnyParserBuilder>
+    ? ParserValues<NuqsMap[T]>
+    : ConstructorParameters<typeof URLSearchParams>[0];
+
+type RouteHasNuqsParsers<T extends string, NuqsMap extends NuqsParsersMap<string>> =
+  NuqsMap[T] extends Record<string, AnyParserBuilder> ? true : false;
+
+type SearchParamsOptions<
+  T extends string,
+  NuqsMap extends NuqsParsersMap<string>,
+  Options extends DefineTypedHrefWithNuqsOptions,
+> = Options["requireSearchParams"] extends true
+  ? RouteHasNuqsParsers<T, NuqsMap> extends true
+    ? { searchParams: SearchParamsFor<T, NuqsMap> }
+    : { searchParams?: SearchParamsFor<T, NuqsMap> }
+  : { searchParams?: SearchParamsFor<T, NuqsMap> };
+
+type PathOptionsFor<
+  T extends string,
+  Routes extends string,
+  RouteParamsMap extends Record<Routes, Record<string, unknown>>,
+  NuqsMap extends NuqsParsersMap<Routes>,
+  Options extends DefineTypedHrefWithNuqsOptions,
+> = T extends Routes
+  ? (RouteHasParams<T, RouteParamsMap> extends true
+      ? { route: T; routeParams: RouteParamsMap[T] }
+      : { route: T }) &
+      SearchParamsOptions<T, NuqsMap, Options> & { hash?: string }
+  : never;
+
+type InnerFn<
+  Routes extends string,
+  RouteParamsMap extends Record<Routes, Record<string, unknown>>,
+  Options extends DefineTypedHrefWithNuqsOptions,
+> = <NuqsMap extends NuqsParsersMap<Routes>>(
+  nuqsMap: NuqsMap,
+) => {
+  $href: <T extends Routes>(
+    options: PathOptionsFor<T, Routes, RouteParamsMap, NuqsMap, Options>,
+  ) => string;
+};
+
 /**
  * Type-safe href generator for Next.js App Router with nuqs integration.
  *
  * Routes that have nuqs parsers defined accept typed searchParams values.
  * Routes without parsers fall back to standard URLSearchParams input.
  *
+ * Pass `{ requireSearchParams: true }` in the second call to make `searchParams`
+ * required on routes that have nuqs parsers defined.
+ *
  * @example
- * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
+ * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()()({
  *   "/search": { q: parseAsString, page: parseAsInteger },
  * });
  *
  * $href({ route: "/search", searchParams: { q: "hello", page: 2 } })
  * // => "/search?q=hello&page=2"
  *
- * $href({ route: "/search", searchParams: { q: "hello", page: null } })
- * // => "/search?q=hello"
+ * @example requireSearchParams
+ * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({ requireSearchParams: true })({
+ *   "/search": { q: parseAsString, page: parseAsInteger },
+ * });
+ *
+ * $href({ route: "/search", searchParams: { q: "hello" } }) // OK
+ * $href({ route: "/search" }) // Type error: searchParams is required
  */
 export function defineTypedHrefWithNuqs<
   Routes extends string,
   RouteParamsMap extends Record<Routes, Record<string, unknown>>,
 >() {
-  type RouteHasParams<T extends Routes> =
-    RouteParamsMap[T] extends Record<string, never> ? false : true;
+  return function <const Options extends DefineTypedHrefWithNuqsOptions = {}>(
+    _options?: Options,
+  ): InnerFn<Routes, RouteParamsMap, Options> {
+    return function <NuqsMap extends NuqsParsersMap<Routes>>(nuqsMap: NuqsMap) {
+      function $href<T extends Routes>(
+        options: PathOptionsFor<T, Routes, RouteParamsMap, NuqsMap, Options>,
+      ): string {
+        const path =
+          "routeParams" in options
+            ? generatePath(
+                options.route,
+                options.routeParams as Record<string, string | string[] | undefined>,
+              )
+            : options.route;
 
-  return function <NuqsMap extends NuqsParsersMap<Routes>>(nuqsMap: NuqsMap) {
-    type SearchParamsFor<T extends Routes> =
-      NuqsMap[T] extends Record<string, AnyParserBuilder>
-        ? ParserValues<NuqsMap[T]>
-        : ConstructorParameters<typeof URLSearchParams>[0];
+        const routeParsers = (nuqsMap as NuqsParsersMap<string>)[options.route];
+        let search = "";
 
-    type PathOptionsFor<T extends Routes> = T extends Routes
-      ? RouteHasParams<T> extends true
-        ? {
-            route: T;
-            routeParams: RouteParamsMap[T];
-            searchParams?: SearchParamsFor<T>;
-            hash?: string;
+        if (options.searchParams != null) {
+          if (routeParsers) {
+            search = createSerializer(routeParsers)(
+              options.searchParams as Record<string, unknown>,
+            );
+          } else {
+            const sp = new URLSearchParams(
+              options.searchParams as ConstructorParameters<typeof URLSearchParams>[0],
+            ).toString();
+            search = sp ? `?${sp}` : "";
           }
-        : {
-            route: T;
-            searchParams?: SearchParamsFor<T>;
-            hash?: string;
-          }
-      : never;
-
-    function $href<T extends Routes>(options: PathOptionsFor<T>): string {
-      const path =
-        "routeParams" in options
-          ? generatePath(
-              options.route,
-              options.routeParams as Record<string, string | string[] | undefined>,
-            )
-          : options.route;
-
-      const routeParsers = (nuqsMap as NuqsParsersMap<string>)[options.route];
-      let search = "";
-
-      if (options.searchParams != null) {
-        if (routeParsers) {
-          search = createSerializer(routeParsers)(options.searchParams as Record<string, unknown>);
-        } else {
-          const sp = new URLSearchParams(
-            options.searchParams as ConstructorParameters<typeof URLSearchParams>[0],
-          ).toString();
-          search = sp ? `?${sp}` : "";
         }
+
+        const hash = options.hash ? `#${options.hash}` : "";
+        return path + search + hash;
       }
 
-      const hash = options.hash ? `#${options.hash}` : "";
-      return path + search + hash;
-    }
-
-    return { $href };
+      return { $href };
+    };
   };
 }

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -25,6 +25,26 @@ type RequiredParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
 };
 
 export type DefineTypedHrefWithNuqsOptions = {
+  /**
+   * When `true`, `searchParams` becomes required on routes that have nuqs parsers defined.
+   *
+   * Among the required route's search params, fields whose parser has `.withDefault()` are optional;
+   * fields without `.withDefault()` (i.e. those whose inferred type includes `null`) are required.
+   *
+   * @default false
+   *
+   * @example
+   * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({ requiredSearchParams: true })({
+   *   "/search": {
+   *     q: parseAsString,                    // required (no withDefault)
+   *     page: parseAsInteger.withDefault(1), // optional (has withDefault)
+   *   },
+   * });
+   *
+   * $href({ route: "/search", searchParams: { q: "hello" } })          // OK
+   * $href({ route: "/search" })                                         // Type error: searchParams is required
+   * $href({ route: "/search", searchParams: { page: 2 } })             // Type error: q is required
+   */
   requiredSearchParams?: boolean;
 };
 

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -13,7 +13,7 @@ type ParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
   [K in keyof Parsers]?: inferParserType<Parsers[K]>;
 };
 
-// null が含まれる（= withDefault なし）フィールドは required、それ以外（withDefault あり）は optional
+// Fields whose inferred type includes null (no withDefault) are required; others (withDefault) are optional.
 type RequiredParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
   [K in keyof Parsers as null extends inferParserType<Parsers[K]> ? K : never]: inferParserType<
     Parsers[K]

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -101,11 +101,16 @@ type InnerFn<
  *
  * @example requiredSearchParams
  * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({ requiredSearchParams: true })({
- *   "/search": { q: parseAsString, page: parseAsInteger },
+ *   "/search": {
+ *     q: parseAsString,                    // required (no withDefault)
+ *     page: parseAsInteger.withDefault(1), // optional (has withDefault)
+ *   },
  * });
  *
- * $href({ route: "/search", searchParams: { q: "hello" } }) // OK
- * $href({ route: "/search" }) // Type error: searchParams is required
+ * $href({ route: "/search", searchParams: { q: "hello" } })        // OK (page is optional)
+ * $href({ route: "/search", searchParams: { q: "hello", page: 2 } }) // OK
+ * $href({ route: "/search" })                                        // Type error: searchParams is required
+ * $href({ route: "/search", searchParams: { page: 2 } })             // Type error: q is required
  */
 export function defineTypedHrefWithNuqs<
   Routes extends string,

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -25,7 +25,7 @@ type RequiredParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
 };
 
 export type DefineTypedHrefWithNuqsOptions = {
-  requireSearchParams?: boolean;
+  requiredSearchParams?: boolean;
 };
 
 type RouteHasParams<
@@ -39,7 +39,7 @@ type SearchParamsFor<
   Options extends DefineTypedHrefWithNuqsOptions,
 > =
   NuqsMap[T] extends Record<string, AnyParserBuilder>
-    ? Options["requireSearchParams"] extends true
+    ? Options["requiredSearchParams"] extends true
       ? RequiredParserValues<NuqsMap[T]>
       : ParserValues<NuqsMap[T]>
     : ConstructorParameters<typeof URLSearchParams>[0];
@@ -51,7 +51,7 @@ type SearchParamsOptions<
   T extends string,
   NuqsMap extends NuqsParsersMap<string>,
   Options extends DefineTypedHrefWithNuqsOptions,
-> = Options["requireSearchParams"] extends true
+> = Options["requiredSearchParams"] extends true
   ? RouteHasNuqsParsers<T, NuqsMap> extends true
     ? { searchParams: SearchParamsFor<T, NuqsMap, Options> }
     : { searchParams?: SearchParamsFor<T, NuqsMap, Options> }
@@ -88,7 +88,7 @@ type InnerFn<
  * Routes that have nuqs parsers defined accept typed searchParams values.
  * Routes without parsers fall back to standard URLSearchParams input.
  *
- * Pass `{ requireSearchParams: true }` in the second call to make `searchParams`
+ * Pass `{ requiredSearchParams: true }` in the second call to make `searchParams`
  * required on routes that have nuqs parsers defined.
  *
  * @example
@@ -99,8 +99,8 @@ type InnerFn<
  * $href({ route: "/search", searchParams: { q: "hello", page: 2 } })
  * // => "/search?q=hello&page=2"
  *
- * @example requireSearchParams
- * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({ requireSearchParams: true })({
+ * @example requiredSearchParams
+ * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({ requiredSearchParams: true })({
  *   "/search": { q: parseAsString, page: parseAsInteger },
  * });
  *

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -13,6 +13,17 @@ type ParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
   [K in keyof Parsers]?: inferParserType<Parsers[K]>;
 };
 
+// null が含まれる（= withDefault なし）フィールドは required、それ以外（withDefault あり）は optional
+type RequiredParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
+  [K in keyof Parsers as null extends inferParserType<Parsers[K]> ? K : never]: inferParserType<
+    Parsers[K]
+  >;
+} & {
+  [K in keyof Parsers as null extends inferParserType<Parsers[K]> ? never : K]?: inferParserType<
+    Parsers[K]
+  >;
+};
+
 export type DefineTypedHrefWithNuqsOptions = {
   requireSearchParams?: boolean;
 };
@@ -22,9 +33,15 @@ type RouteHasParams<
   RouteParamsMap extends Record<string, Record<string, unknown>>,
 > = RouteParamsMap[T] extends Record<string, never> ? false : true;
 
-type SearchParamsFor<T extends string, NuqsMap extends NuqsParsersMap<string>> =
+type SearchParamsFor<
+  T extends string,
+  NuqsMap extends NuqsParsersMap<string>,
+  Options extends DefineTypedHrefWithNuqsOptions,
+> =
   NuqsMap[T] extends Record<string, AnyParserBuilder>
-    ? ParserValues<NuqsMap[T]>
+    ? Options["requireSearchParams"] extends true
+      ? RequiredParserValues<NuqsMap[T]>
+      : ParserValues<NuqsMap[T]>
     : ConstructorParameters<typeof URLSearchParams>[0];
 
 type RouteHasNuqsParsers<T extends string, NuqsMap extends NuqsParsersMap<string>> =
@@ -36,9 +53,9 @@ type SearchParamsOptions<
   Options extends DefineTypedHrefWithNuqsOptions,
 > = Options["requireSearchParams"] extends true
   ? RouteHasNuqsParsers<T, NuqsMap> extends true
-    ? { searchParams: SearchParamsFor<T, NuqsMap> }
-    : { searchParams?: SearchParamsFor<T, NuqsMap> }
-  : { searchParams?: SearchParamsFor<T, NuqsMap> };
+    ? { searchParams: SearchParamsFor<T, NuqsMap, Options> }
+    : { searchParams?: SearchParamsFor<T, NuqsMap, Options> }
+  : { searchParams?: SearchParamsFor<T, NuqsMap, Options> };
 
 type PathOptionsFor<
   T extends string,


### PR DESCRIPTION
## Summary

fix https://linear.app/plainbrew/issue/PC-67

- `defineTypedHrefWithNuqs` を 3 重カリー化し、第 2 呼び出しで `options` を受け取れるようにした
- `{ requiredSearchParams: true }` を渡すと、nuqs パーサーが定義されたルートで `searchParams` オブジェクトが必須になる
- `.withDefault()` なしのフィールドは必須、`.withDefault()` ありのフィールドは任意になる
- `DefineTypedHrefWithNuqsOptions` 型を export に追加

## Breaking change

既存コードは `()()` に変更が必要:

```ts
// before
defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({ nuqsMap })

// after
defineTypedHrefWithNuqs<Routes, RouteParamsMap>()()({ nuqsMap })
```

## 呼び出し方

```ts
// デフォルト（searchParams 任意）
const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()()({
  "/search": { q: parseAsString },
});

// requiredSearchParams: true（searchParams 必須・フィールドも型に応じて必須）
const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()(
  { requiredSearchParams: true },
)({
  "/search": {
    q: parseAsString,                    // required
    page: parseAsInteger.withDefault(1), // optional
  },
});
```

## 設計メモ

TypeScript の部分的型引数指定の制限（`<Routes, RouteParamsMap>` を明示すると残りの型パラメータが引数から推論されない）を、3 重カリーにすることで回避。第 2 呼び出し時点では型引数がゼロなため `const Options` が引数から正しく推論される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
