### PR TITLE
feat(next-typed-href): add nonNullableSearchParams option

### DIFF
--- a/packages/next-typed-href/src/nuqs.test.ts
+++ b/packages/next-typed-href/src/nuqs.test.ts
@@ -215,41 +215,75 @@ describe("requiredSearchParams option", () => {
   });
 });
 
-describe('requiredSearchParams: "strict" option', () => {
+describe("nonNullableSearchParams option (independent)", () => {
+  // nonNullableSearchParams: true alone — searchParams is still optional, but null is disallowed
+  const { $href: $hrefNN } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
+    nonNullableSearchParams: true,
+  })({
+    "/search": { q: parseAsString, page: parseAsInteger.withDefault(1) },
+  });
+
+  test("accepts string param", () => {
+    expect($hrefNN({ route: "/search", searchParams: { q: "hello" } })).toBe("/search?q=hello");
+  });
+
+  test("accepts both fields", () => {
+    expect($hrefNN({ route: "/search", searchParams: { q: "hello", page: 2 } })).toBe(
+      "/search?q=hello&page=2",
+    );
+  });
+
+  test("works without searchParams (still optional)", () => {
+    expect($hrefNN({ route: "/search" })).toBe("/search");
+  });
+
+  test("non-nuqs routes still have optional searchParams", () => {
+    expect($hrefNN({ route: "/posts" })).toBe("/posts");
+    expect($hrefNN({ route: "/posts", searchParams: { page: "1" } })).toBe("/posts?page=1");
+  });
+
+  test("rejects null for nullable field (type error)", () => {
+    // @ts-expect-error: null is not allowed when nonNullableSearchParams: true
+    $hrefNN({ route: "/search", searchParams: { q: null } });
+  });
+});
+
+describe("nonNullableSearchParams + requiredSearchParams combined", () => {
   // q: no withDefault → required + non-nullable, page: withDefault → optional
-  const { $href: $hrefStrict } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
-    requiredSearchParams: "strict",
+  const { $href: $hrefBoth } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
+    requiredSearchParams: true,
+    nonNullableSearchParams: true,
   })({
     "/search": { q: parseAsString, page: parseAsInteger.withDefault(1) },
   });
 
   test("accepts required field only (withDefault field omitted)", () => {
-    expect($hrefStrict({ route: "/search", searchParams: { q: "hello" } })).toBe("/search?q=hello");
+    expect($hrefBoth({ route: "/search", searchParams: { q: "hello" } })).toBe("/search?q=hello");
   });
 
   test("accepts both fields", () => {
-    expect($hrefStrict({ route: "/search", searchParams: { q: "hello", page: 2 } })).toBe(
+    expect($hrefBoth({ route: "/search", searchParams: { q: "hello", page: 2 } })).toBe(
       "/search?q=hello&page=2",
     );
   });
 
   test("non-nuqs routes still have optional searchParams", () => {
-    expect($hrefStrict({ route: "/posts" })).toBe("/posts");
-    expect($hrefStrict({ route: "/posts", searchParams: { page: "1" } })).toBe("/posts?page=1");
+    expect($hrefBoth({ route: "/posts" })).toBe("/posts");
+    expect($hrefBoth({ route: "/posts", searchParams: { page: "1" } })).toBe("/posts?page=1");
   });
 
   test("rejects missing searchParams object (type error)", () => {
     // @ts-expect-error: searchParams is required
-    $hrefStrict({ route: "/search" });
+    $hrefBoth({ route: "/search" });
   });
 
   test("rejects missing required field (type error)", () => {
-    // @ts-expect-error: q is required
-    $hrefStrict({ route: "/search", searchParams: { page: 2 } });
+    // @ts-expect-error: q has no withDefault, so it is required
+    $hrefBoth({ route: "/search", searchParams: { page: 2 } });
   });
 
   test("rejects null for required field (type error)", () => {
-    // @ts-expect-error: null is not allowed in strict mode
-    $hrefStrict({ route: "/search", searchParams: { q: null } });
+    // @ts-expect-error: null is not allowed when nonNullableSearchParams: true
+    $hrefBoth({ route: "/search", searchParams: { q: null } });
   });
 });

--- a/packages/next-typed-href/src/nuqs.test.ts
+++ b/packages/next-typed-href/src/nuqs.test.ts
@@ -214,3 +214,42 @@ describe("requiredSearchParams option", () => {
     $hrefReq({ route: "/search", searchParams: { page: 2 } });
   });
 });
+
+describe('requiredSearchParams: "strict" option', () => {
+  // q: no withDefault → required + non-nullable, page: withDefault → optional
+  const { $href: $hrefStrict } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
+    requiredSearchParams: "strict",
+  })({
+    "/search": { q: parseAsString, page: parseAsInteger.withDefault(1) },
+  });
+
+  test("accepts required field only (withDefault field omitted)", () => {
+    expect($hrefStrict({ route: "/search", searchParams: { q: "hello" } })).toBe("/search?q=hello");
+  });
+
+  test("accepts both fields", () => {
+    expect($hrefStrict({ route: "/search", searchParams: { q: "hello", page: 2 } })).toBe(
+      "/search?q=hello&page=2",
+    );
+  });
+
+  test("non-nuqs routes still have optional searchParams", () => {
+    expect($hrefStrict({ route: "/posts" })).toBe("/posts");
+    expect($hrefStrict({ route: "/posts", searchParams: { page: "1" } })).toBe("/posts?page=1");
+  });
+
+  test("rejects missing searchParams object (type error)", () => {
+    // @ts-expect-error: searchParams is required
+    $hrefStrict({ route: "/search" });
+  });
+
+  test("rejects missing required field (type error)", () => {
+    // @ts-expect-error: q is required
+    $hrefStrict({ route: "/search", searchParams: { page: 2 } });
+  });
+
+  test("rejects null for required field (type error)", () => {
+    // @ts-expect-error: null is not allowed in strict mode
+    $hrefStrict({ route: "/search", searchParams: { q: null } });
+  });
+});

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -13,30 +13,32 @@ type ParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
   [K in keyof Parsers]?: inferParserType<Parsers[K]>;
 };
 
-// withDefault なし（nullable）→ required、withDefault あり（non-nullable）→ optional
-type RequiredParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
-  [K in keyof Parsers as null extends inferParserType<Parsers[K]> ? K : never]: inferParserType<
-    Parsers[K]
-  >;
-} & {
-  [K in keyof Parsers as null extends inferParserType<Parsers[K]> ? never : K]?: inferParserType<
-    Parsers[K]
-  >;
-};
+type FieldType<P extends AnyParserBuilder, NonNullable extends boolean> = NonNullable extends true
+  ? globalThis.NonNullable<inferParserType<P>>
+  : inferParserType<P>;
 
-// withDefault なし → required かつ NonNullable、withDefault あり → optional
-type StrictParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
-  [K in keyof Parsers as null extends inferParserType<Parsers[K]> ? K : never]: NonNullable<
-    inferParserType<Parsers[K]>
-  >;
+// withDefault なし（nullable）かつ RequiredFields=true のフィールドは required、それ以外は optional
+type ParserValuesWithOptions<
+  Parsers extends Record<string, AnyParserBuilder>,
+  RequiredFields extends boolean,
+  NonNullableFields extends boolean,
+> = {
+  [K in keyof Parsers as RequiredFields extends true
+    ? null extends inferParserType<Parsers[K]>
+      ? K
+      : never
+    : never]: FieldType<Parsers[K], NonNullableFields>;
 } & {
-  [K in keyof Parsers as null extends inferParserType<Parsers[K]> ? never : K]?: inferParserType<
-    Parsers[K]
-  >;
+  [K in keyof Parsers as RequiredFields extends true
+    ? null extends inferParserType<Parsers[K]>
+      ? never
+      : K
+    : K]?: FieldType<Parsers[K], NonNullableFields>;
 };
 
 export type DefineTypedHrefWithNuqsOptions = {
-  requiredSearchParams?: boolean | "strict";
+  requiredSearchParams?: boolean;
+  nonNullableSearchParams?: boolean;
 };
 
 type RouteHasParams<
@@ -50,10 +52,14 @@ type SearchParamsFor<
   Options extends DefineTypedHrefWithNuqsOptions,
 > =
   NuqsMap[T] extends Record<string, AnyParserBuilder>
-    ? Options["requiredSearchParams"] extends "strict"
-      ? StrictParserValues<NuqsMap[T]>
-      : Options["requiredSearchParams"] extends true | "strict"
-        ? RequiredParserValues<NuqsMap[T]>
+    ? Options["requiredSearchParams"] extends true
+      ? ParserValuesWithOptions<
+          NuqsMap[T],
+          true,
+          Options["nonNullableSearchParams"] extends true ? true : false
+        >
+      : Options["nonNullableSearchParams"] extends true
+        ? ParserValuesWithOptions<NuqsMap[T], false, true>
         : ParserValues<NuqsMap[T]>
     : ConstructorParameters<typeof URLSearchParams>[0];
 
@@ -64,7 +70,7 @@ type SearchParamsOptions<
   T extends string,
   NuqsMap extends NuqsParsersMap<string>,
   Options extends DefineTypedHrefWithNuqsOptions,
-> = Options["requiredSearchParams"] extends true | "strict"
+> = Options["requiredSearchParams"] extends true
   ? RouteHasNuqsParsers<T, NuqsMap> extends true
     ? { searchParams: SearchParamsFor<T, NuqsMap, Options> }
     : { searchParams?: SearchParamsFor<T, NuqsMap, Options> }
@@ -101,9 +107,9 @@ type InnerFn<
  * Routes that have nuqs parsers defined accept typed searchParams values.
  * Routes without parsers fall back to standard URLSearchParams input.
  *
- * Pass `{ requiredSearchParams: true }` in the second call to make `searchParams`
- * required on routes that have nuqs parsers defined.
- * Pass `{ requiredSearchParams: "strict" }` to additionally disallow `null` values.
+ * Options (independent, can be combined):
+ * - `requiredSearchParams: true` — searchParams object required; fields without `.withDefault()` become required
+ * - `nonNullableSearchParams: true` — `null` disallowed for all fields (applies regardless of requiredSearchParams)
  *
  * @example
  * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()()({
@@ -121,21 +127,29 @@ type InnerFn<
  *   },
  * });
  *
- * $href({ route: "/search", searchParams: { q: "hello" } })   // OK
- * $href({ route: "/search", searchParams: { q: null } })       // OK (null clears the param)
- * $href({ route: "/search" })                                   // Type error: searchParams is required
+ * $href({ route: "/search", searchParams: { q: "hello" } })  // OK
+ * $href({ route: "/search", searchParams: { q: null } })      // OK (null clears the param)
+ * $href({ route: "/search" })                                  // Type error: searchParams is required
  *
- * @example requiredSearchParams: "strict"
- * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({ requiredSearchParams: "strict" })({
- *   "/search": {
- *     q: parseAsString,                    // required, null not allowed
- *     page: parseAsInteger.withDefault(1), // optional
- *   },
+ * @example nonNullableSearchParams: true
+ * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({ nonNullableSearchParams: true })({
+ *   "/search": { q: parseAsString, page: parseAsInteger.withDefault(1) },
  * });
  *
  * $href({ route: "/search", searchParams: { q: "hello" } })  // OK
  * $href({ route: "/search", searchParams: { q: null } })      // Type error: null not allowed
+ *
+ * @example both options
+ * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
+ *   requiredSearchParams: true,
+ *   nonNullableSearchParams: true,
+ * })({
+ *   "/search": { q: parseAsString, page: parseAsInteger.withDefault(1) },
+ * });
+ *
+ * $href({ route: "/search", searchParams: { q: "hello" } })  // OK
  * $href({ route: "/search" })                                  // Type error: searchParams is required
+ * $href({ route: "/search", searchParams: { q: null } })      // Type error: null not allowed
  */
 export function defineTypedHrefWithNuqs<
   Routes extends string,

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -13,7 +13,7 @@ type ParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
   [K in keyof Parsers]?: inferParserType<Parsers[K]>;
 };
 
-// null が含まれる（= withDefault なし）フィールドは required、それ以外（withDefault あり）は optional
+// withDefault なし（nullable）→ required、withDefault あり（non-nullable）→ optional
 type RequiredParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
   [K in keyof Parsers as null extends inferParserType<Parsers[K]> ? K : never]: inferParserType<
     Parsers[K]
@@ -24,8 +24,19 @@ type RequiredParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
   >;
 };
 
+// withDefault なし → required かつ NonNullable、withDefault あり → optional
+type StrictParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
+  [K in keyof Parsers as null extends inferParserType<Parsers[K]> ? K : never]: NonNullable<
+    inferParserType<Parsers[K]>
+  >;
+} & {
+  [K in keyof Parsers as null extends inferParserType<Parsers[K]> ? never : K]?: inferParserType<
+    Parsers[K]
+  >;
+};
+
 export type DefineTypedHrefWithNuqsOptions = {
-  requiredSearchParams?: boolean;
+  requiredSearchParams?: boolean | "strict";
 };
 
 type RouteHasParams<
@@ -39,9 +50,11 @@ type SearchParamsFor<
   Options extends DefineTypedHrefWithNuqsOptions,
 > =
   NuqsMap[T] extends Record<string, AnyParserBuilder>
-    ? Options["requiredSearchParams"] extends true
-      ? RequiredParserValues<NuqsMap[T]>
-      : ParserValues<NuqsMap[T]>
+    ? Options["requiredSearchParams"] extends "strict"
+      ? StrictParserValues<NuqsMap[T]>
+      : Options["requiredSearchParams"] extends true | "strict"
+        ? RequiredParserValues<NuqsMap[T]>
+        : ParserValues<NuqsMap[T]>
     : ConstructorParameters<typeof URLSearchParams>[0];
 
 type RouteHasNuqsParsers<T extends string, NuqsMap extends NuqsParsersMap<string>> =
@@ -51,7 +64,7 @@ type SearchParamsOptions<
   T extends string,
   NuqsMap extends NuqsParsersMap<string>,
   Options extends DefineTypedHrefWithNuqsOptions,
-> = Options["requiredSearchParams"] extends true
+> = Options["requiredSearchParams"] extends true | "strict"
   ? RouteHasNuqsParsers<T, NuqsMap> extends true
     ? { searchParams: SearchParamsFor<T, NuqsMap, Options> }
     : { searchParams?: SearchParamsFor<T, NuqsMap, Options> }
@@ -90,6 +103,7 @@ type InnerFn<
  *
  * Pass `{ requiredSearchParams: true }` in the second call to make `searchParams`
  * required on routes that have nuqs parsers defined.
+ * Pass `{ requiredSearchParams: "strict" }` to additionally disallow `null` values.
  *
  * @example
  * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()()({
@@ -99,18 +113,29 @@ type InnerFn<
  * $href({ route: "/search", searchParams: { q: "hello", page: 2 } })
  * // => "/search?q=hello&page=2"
  *
- * @example requiredSearchParams
+ * @example requiredSearchParams: true
  * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({ requiredSearchParams: true })({
  *   "/search": {
- *     q: parseAsString,                    // required (no withDefault)
- *     page: parseAsInteger.withDefault(1), // optional (has withDefault)
+ *     q: parseAsString,                    // required, null allowed
+ *     page: parseAsInteger.withDefault(1), // optional
  *   },
  * });
  *
- * $href({ route: "/search", searchParams: { q: "hello" } })        // OK (page is optional)
- * $href({ route: "/search", searchParams: { q: "hello", page: 2 } }) // OK
- * $href({ route: "/search" })                                        // Type error: searchParams is required
- * $href({ route: "/search", searchParams: { page: 2 } })             // Type error: q is required
+ * $href({ route: "/search", searchParams: { q: "hello" } })   // OK
+ * $href({ route: "/search", searchParams: { q: null } })       // OK (null clears the param)
+ * $href({ route: "/search" })                                   // Type error: searchParams is required
+ *
+ * @example requiredSearchParams: "strict"
+ * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({ requiredSearchParams: "strict" })({
+ *   "/search": {
+ *     q: parseAsString,                    // required, null not allowed
+ *     page: parseAsInteger.withDefault(1), // optional
+ *   },
+ * });
+ *
+ * $href({ route: "/search", searchParams: { q: "hello" } })  // OK
+ * $href({ route: "/search", searchParams: { q: null } })      // Type error: null not allowed
+ * $href({ route: "/search" })                                  // Type error: searchParams is required
  */
 export function defineTypedHrefWithNuqs<
   Routes extends string,


### PR DESCRIPTION
## 概要

`defineTypedHrefWithNuqs` に `nonNullableSearchParams` オプションを追加する。  
`requiredSearchParams` とは独立した別軸のオプションで、組み合わせて使用可能。

## オプション対比

| オプション | 効果 |
|-----------|------|
| デフォルト | `searchParams` は optional、`null` も許容 |
| `requiredSearchParams: true` | nuqs parsers があるルートで `searchParams` が必須、withDefault なしフィールドが required（`null` は許容） |
| `nonNullableSearchParams: true` | すべてのフィールドで `null` を型エラーにする（`searchParams` 自体は optional のまま） |
| 両方 `true` | `searchParams` が必須、withDefault なしフィールドが required かつ non-nullable |

## 型の変化

```
| モード                                          | withDefault なし        | withDefault あり |
|-------------------------------------------------|------------------------|-----------------|
| デフォルト                                       | q?: string \| null     | q?: string      |
| requiredSearchParams: true                      | q: string \| null      | q?: string      |
| nonNullableSearchParams: true                   | q?: string             | q?: string      |
| requiredSearchParams: true + nonNullableSearchParams: true | q: string | q?: string      |
```

## 使用例

```ts
// nonNullableSearchParams のみ — searchParams は optional、null は型エラー
const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
  nonNullableSearchParams: true,
})({ "/search": { q: parseAsString, page: parseAsInteger.withDefault(1) } });

$href({ route: "/search" })                                  // OK
$href({ route: "/search", searchParams: { q: "hello" } })  // OK
$href({ route: "/search", searchParams: { q: null } })      // Type error

// 両方 — searchParams が必須、null も型エラー
const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
  requiredSearchParams: true,
  nonNullableSearchParams: true,
})({ "/search": { q: parseAsString, page: parseAsInteger.withDefault(1) } });

$href({ route: "/search" })                                  // Type error: searchParams is required
$href({ route: "/search", searchParams: { q: "hello" } })  // OK
$href({ route: "/search", searchParams: { q: null } })      // Type error: null not allowed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
