### PR TITLE
refactor(next-typed-href): replace triple-curry with builder pattern, add requiredSearchParams

### DIFF
--- a/.changeset/nuqs-builder-pattern.md
+++ b/.changeset/nuqs-builder-pattern.md
@@ -1,0 +1,58 @@
+---
+"@plainbrew/next-typed-href": minor
+---
+
+refactor: replace triple-curry with builder pattern, add `.withOptions()`
+
+### Breaking changes
+
+Both `defineTypedHref` and `defineTypedHrefWithNuqs` now use a builder pattern
+inspired by tRPC's `initTRPC.context<T>().create()`.
+
+#### `defineTypedHref`
+
+```ts
+// before
+defineTypedHref<Routes, RouteParamsMap>();
+
+// after
+defineTypedHref.routes<Routes, RouteParamsMap>();
+```
+
+#### `defineTypedHrefWithNuqs`
+
+```ts
+// before
+defineTypedHrefWithNuqs<Routes, RouteParamsMap>()(nuqsMap);
+defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({ requiredSearchParams: true })(nuqsMap);
+
+// after
+defineTypedHrefWithNuqs.routes<Routes, RouteParamsMap>().nuqs(nuqsMap);
+defineTypedHrefWithNuqs
+  .routes<Routes, RouteParamsMap>()
+  .withOptions({ requiredSearchParams: true })
+  .nuqs(nuqsMap);
+```
+
+### New feature: `.withOptions()`
+
+`requiredSearchParams: true` を渡すと、nuqs パーサーが定義されているルートで `searchParams` が必須になる。
+
+- `.withDefault()` なし → フィールドが required（`null` は渡せる）
+- `.withDefault()` あり → フィールドが optional
+
+```ts
+const { $href } = defineTypedHrefWithNuqs
+  .routes<Routes, RouteParamsMap>()
+  .withOptions({ requiredSearchParams: true })
+  .nuqs({
+    "/search": {
+      q: parseAsString, // required (no withDefault)
+      page: parseAsInteger.withDefault(1), // optional (has withDefault)
+    },
+  });
+
+$href({ route: "/search", searchParams: { q: "hello" } }); // OK
+$href({ route: "/search" }); // Type error: searchParams is required
+$href({ route: "/search", searchParams: { page: 2 } }); // Type error: q is required
+```

--- a/examples/example-next-typed-href-nuqs/src/lib/href.ts
+++ b/examples/example-next-typed-href-nuqs/src/lib/href.ts
@@ -5,6 +5,6 @@ import { searchParams as searchSearchParams } from "@/app/search/searchParams";
 
 type AppRouteParamsMap = { [Route in AppRoutes]: ParamsOf<Route> };
 
-export const { $href } = defineTypedHrefWithNuqs<AppRoutes, AppRouteParamsMap>()()({
-  "/search": searchSearchParams,
-});
+export const { $href } = defineTypedHrefWithNuqs
+  .routes<AppRoutes, AppRouteParamsMap>()
+  .nuqs({ "/search": searchSearchParams });

--- a/packages/next-typed-href/src/common/generatePath.ts
+++ b/packages/next-typed-href/src/common/generatePath.ts
@@ -1,3 +1,26 @@
+/**
+ * Substitutes dynamic segments in a Next.js App Router path template with values
+ * from `routeParams`. Values are URL-encoded.
+ *
+ * Supported segment forms:
+ * - Dynamic segments `[slug]` — replaced with the encoded string value.
+ * - Catch-all `[...rest]` — replaced with `/`-joined encoded array values.
+ * - Optional catch-all `[[...rest]]` — empty when the value is `undefined`,
+ *   otherwise behaves like catch-all.
+ *
+ * Throws when a required param is missing or has the wrong type
+ * (e.g. a non-array passed to a catch-all segment).
+ *
+ * @example
+ * generatePath("/users/[id]", { id: "42" });
+ * // => "/users/42"
+ *
+ * generatePath("/blog/[...slug]", { slug: ["2026", "hello"] });
+ * // => "/blog/2026/hello"
+ *
+ * generatePath("/docs/[[...path]]", { path: undefined });
+ * // => "/docs/"
+ */
 export function generatePath<T extends string>(
   route: T,
   routeParams: Record<string, string | string[] | undefined>,

--- a/packages/next-typed-href/src/common/resolveRoutePath.ts
+++ b/packages/next-typed-href/src/common/resolveRoutePath.ts
@@ -1,5 +1,21 @@
 import { generatePath } from "./generatePath";
 
+/**
+ * Resolves the path portion of an href from a `$href` options object.
+ *
+ * - When `routeParams` is provided, substitutes dynamic segments via {@link generatePath}.
+ * - Otherwise returns `route` as-is (static route, no substitution).
+ *
+ * Shared by `defineTypedHref` and `defineTypedHrefWithNuqs` so the
+ * `"routeParams" in options ? generatePath(...) : route` branch lives in one place.
+ *
+ * @example
+ * resolveRoutePath({ route: "/" });
+ * // => "/"
+ *
+ * resolveRoutePath({ route: "/users/[id]", routeParams: { id: "42" } });
+ * // => "/users/42"
+ */
 export function resolveRoutePath<T extends string>(
   options: { route: T; routeParams?: Record<string, string | string[] | undefined> } | { route: T },
 ): string {

--- a/packages/next-typed-href/src/common/resolveRoutePath.ts
+++ b/packages/next-typed-href/src/common/resolveRoutePath.ts
@@ -1,0 +1,8 @@
+import { generatePath } from "./generatePath";
+
+export function resolveRoutePath<T extends string>(
+  options: { route: T; routeParams?: Record<string, string | string[] | undefined> } | { route: T },
+): string {
+  if (!("routeParams" in options) || options.routeParams == null) return options.route;
+  return generatePath(options.route, options.routeParams);
+}

--- a/packages/next-typed-href/src/common/types.ts
+++ b/packages/next-typed-href/src/common/types.ts
@@ -1,8 +1,38 @@
+/**
+ * Resolves at the type level whether a given route has dynamic params.
+ *
+ * Returns `true` when `RouteParamsMap[T]` has any keys, `false` when it is
+ * `Record<string, never>` (i.e. a static route with no dynamic segments).
+ *
+ * @example
+ * type Map = { "/": Record<string, never>; "/users/[id]": { id: string } };
+ * type A = RouteHasParams<"/", Map>;          // false
+ * type B = RouteHasParams<"/users/[id]", Map>; // true
+ */
 export type RouteHasParams<
   T extends string,
   RouteParamsMap extends Record<string, Record<string, unknown>>,
 > = RouteParamsMap[T] extends Record<string, never> ? false : true;
 
+/**
+ * Builds the `route` + (optional) `routeParams` shape for a single route.
+ *
+ * - If the route has dynamic params, the result requires `routeParams`.
+ * - If not, only `route` is required.
+ *
+ * Used by both `defineTypedHref` and `defineTypedHrefWithNuqs` to share the
+ * "route identity" portion of their `$href` argument types.
+ *
+ * @example
+ * type Routes = "/" | "/users/[id]";
+ * type Map = { "/": Record<string, never>; "/users/[id]": { id: string } };
+ *
+ * type Home = RouteIdentityFor<"/", Routes, Map>;
+ * // => { route: "/" }
+ *
+ * type User = RouteIdentityFor<"/users/[id]", Routes, Map>;
+ * // => { route: "/users/[id]"; routeParams: { id: string } }
+ */
 export type RouteIdentityFor<
   T extends string,
   Routes extends string,

--- a/packages/next-typed-href/src/common/types.ts
+++ b/packages/next-typed-href/src/common/types.ts
@@ -1,0 +1,14 @@
+export type RouteHasParams<
+  T extends string,
+  RouteParamsMap extends Record<string, Record<string, unknown>>,
+> = RouteParamsMap[T] extends Record<string, never> ? false : true;
+
+export type RouteIdentityFor<
+  T extends string,
+  Routes extends string,
+  RouteParamsMap extends Record<Routes, Record<string, unknown>>,
+> = T extends Routes
+  ? RouteHasParams<T, RouteParamsMap> extends true
+    ? { route: T; routeParams: RouteParamsMap[T] }
+    : { route: T }
+  : never;

--- a/packages/next-typed-href/src/index.test.ts
+++ b/packages/next-typed-href/src/index.test.ts
@@ -13,7 +13,7 @@ type RouteParamsMap = {
   "/search": Record<string, never>;
 };
 
-const { $href } = defineTypedHref<Routes, RouteParamsMap>();
+const { $href } = defineTypedHref.routes<Routes, RouteParamsMap>();
 
 describe("static routes", () => {
   test("returns route as-is when no params", () => {

--- a/packages/next-typed-href/src/index.ts
+++ b/packages/next-typed-href/src/index.ts
@@ -1,10 +1,6 @@
 /**
  * Type-safe href generator for Next.js App Router
  *
- * @template Routes - Union type of all route paths (with trailing slash)
- * @template RouteParamsMap - Map from route to its dynamic segment params `{ [Route in Routes]: ParamsOf<Route> }`
- * @returns Object with `$href` function for generating type-safe URLs
- *
  * @example
  * type Routes = "/" | "/users/" | "/users/[id]/";
  * type RouteParamsMap = {
@@ -13,7 +9,7 @@
  *   "/users/[id]/": { id: string };
  * };
  *
- * const { $href } = defineTypedHref<Routes, RouteParamsMap>();
+ * const { $href } = defineTypedHref.routes<Routes, RouteParamsMap>();
  *
  * $href({ route: "/" })
  * // => "/"
@@ -26,29 +22,46 @@
  */
 import { generatePath } from "./common/generatePath";
 
-export function defineTypedHref<
+type TypedHrefBuilder = {
+  routes: <
+    Routes extends string,
+    RouteParamsMap extends Record<Routes, Record<string, unknown>>,
+  >() => {
+    $href: <T extends Routes>(options: PathOptionsFor<T, Routes, RouteParamsMap>) => string;
+  };
+};
+
+type RouteHasParams<
+  T extends string,
+  RouteParamsMap extends Record<string, Record<string, unknown>>,
+> = RouteParamsMap[T] extends Record<string, never> ? false : true;
+
+type PathOptionsFor<
+  T extends string,
+  Routes extends string,
+  RouteParamsMap extends Record<Routes, Record<string, unknown>>,
+> = T extends Routes
+  ? RouteHasParams<T, RouteParamsMap> extends true
+    ? {
+        route: T;
+        routeParams: RouteParamsMap[T];
+        searchParams?: ConstructorParameters<typeof URLSearchParams>[0];
+        hash?: string;
+      }
+    : {
+        route: T;
+        searchParams?: ConstructorParameters<typeof URLSearchParams>[0];
+        hash?: string;
+      }
+  : never;
+
+function createRoutes<
   Routes extends string,
   RouteParamsMap extends Record<Routes, Record<string, unknown>>,
 >() {
-  type RouteHasParams<T extends Routes> =
-    RouteParamsMap[T] extends Record<string, never> ? false : true;
-
-  type PathOptionsFor<T extends Routes> = T extends Routes
-    ? RouteHasParams<T> extends true
-      ? {
-          route: T;
-          routeParams: RouteParamsMap[T];
-          searchParams?: ConstructorParameters<typeof URLSearchParams>[0];
-          hash?: string;
-        }
-      : {
-          route: T;
-          searchParams?: ConstructorParameters<typeof URLSearchParams>[0];
-          hash?: string;
-        }
-    : never;
-
-  function resolvePath<T extends Routes>(options: PathOptionsFor<T>): string {
+  function resolvePath<T extends Routes>(
+    options: PathOptionsFor<T, Routes, RouteParamsMap>,
+  ): string {
     if (!("routeParams" in options)) return options.route;
 
     const { routeParams } = options as unknown as {
@@ -59,7 +72,7 @@ export function defineTypedHref<
     return generatePath(options.route, routeParams);
   }
 
-  function $href<T extends Routes>(options: PathOptionsFor<T>): string {
+  function $href<T extends Routes>(options: PathOptionsFor<T, Routes, RouteParamsMap>): string {
     const path = resolvePath(options);
     const search = options.searchParams
       ? `?${new URLSearchParams(options.searchParams).toString()}`
@@ -70,3 +83,7 @@ export function defineTypedHref<
 
   return { $href };
 }
+
+export const defineTypedHref: TypedHrefBuilder = {
+  routes: createRoutes,
+};

--- a/packages/next-typed-href/src/index.ts
+++ b/packages/next-typed-href/src/index.ts
@@ -20,7 +20,8 @@
  * $href({ route: "/users/", searchParams: { q: "hello" }, hash: "top" })
  * // => "/users/?q=hello#top"
  */
-import { generatePath } from "./common/generatePath";
+import { resolveRoutePath } from "./common/resolveRoutePath";
+import type { RouteIdentityFor } from "./common/types";
 
 type TypedHrefBuilder = {
   routes: <
@@ -31,49 +32,23 @@ type TypedHrefBuilder = {
   };
 };
 
-type RouteHasParams<
-  T extends string,
-  RouteParamsMap extends Record<string, Record<string, unknown>>,
-> = RouteParamsMap[T] extends Record<string, never> ? false : true;
-
 type PathOptionsFor<
   T extends string,
   Routes extends string,
   RouteParamsMap extends Record<Routes, Record<string, unknown>>,
-> = T extends Routes
-  ? RouteHasParams<T, RouteParamsMap> extends true
-    ? {
-        route: T;
-        routeParams: RouteParamsMap[T];
-        searchParams?: ConstructorParameters<typeof URLSearchParams>[0];
-        hash?: string;
-      }
-    : {
-        route: T;
-        searchParams?: ConstructorParameters<typeof URLSearchParams>[0];
-        hash?: string;
-      }
-  : never;
+> = RouteIdentityFor<T, Routes, RouteParamsMap> & {
+  searchParams?: ConstructorParameters<typeof URLSearchParams>[0];
+  hash?: string;
+};
 
 function createRoutes<
   Routes extends string,
   RouteParamsMap extends Record<Routes, Record<string, unknown>>,
 >() {
-  function resolvePath<T extends Routes>(
-    options: PathOptionsFor<T, Routes, RouteParamsMap>,
-  ): string {
-    if (!("routeParams" in options)) return options.route;
-
-    const { routeParams } = options as unknown as {
-      route: T;
-      routeParams: Record<string, string | string[] | undefined>;
-    };
-
-    return generatePath(options.route, routeParams);
-  }
-
   function $href<T extends Routes>(options: PathOptionsFor<T, Routes, RouteParamsMap>): string {
-    const path = resolvePath(options);
+    const path = resolveRoutePath(
+      options as { route: T; routeParams?: Record<string, string | string[] | undefined> },
+    );
     const search = options.searchParams
       ? `?${new URLSearchParams(options.searchParams).toString()}`
       : "";

--- a/packages/next-typed-href/src/nuqs.test.ts
+++ b/packages/next-typed-href/src/nuqs.test.ts
@@ -1,5 +1,5 @@
 import { parseAsBoolean, parseAsInteger, parseAsString } from "nuqs/server";
-import { describe, expect, test } from "vitest";
+import { describe, expect, expectTypeOf, test } from "vitest";
 
 import { defineTypedHrefWithNuqs } from "./nuqs";
 
@@ -12,7 +12,7 @@ type RouteParamsMap = {
   "/posts": Record<string, never>;
 };
 
-const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()()({
+const { $href } = defineTypedHrefWithNuqs.routes<Routes, RouteParamsMap>().nuqs({
   "/search": {
     q: parseAsString,
     page: parseAsInteger,
@@ -48,9 +48,12 @@ describe("nuqs-typed searchParams", () => {
   });
 
   test("skips undefined values", () => {
-    expect($href({ route: "/search", searchParams: { q: "hello", page: undefined } })).toBe(
-      "/search?q=hello",
-    );
+    expect(
+      $href({
+        route: "/search",
+        searchParams: { q: "hello", page: undefined },
+      }),
+    ).toBe("/search?q=hello");
   });
 
   test("returns no query string when all values are null", () => {
@@ -62,9 +65,13 @@ describe("nuqs-typed searchParams", () => {
   });
 
   test("appends hash", () => {
-    expect($href({ route: "/search", searchParams: { q: "hello" }, hash: "results" })).toBe(
-      "/search?q=hello#results",
-    );
+    expect(
+      $href({
+        route: "/search",
+        searchParams: { q: "hello" },
+        hash: "results",
+      }),
+    ).toBe("/search?q=hello#results");
   });
 });
 
@@ -103,7 +110,7 @@ describe("type errors on wrong param types", () => {
 
 describe("dynamic segments work with nuqs searchParams", () => {
   test("resolves route params and adds nuqs-typed searchParams", () => {
-    const { $href: $hrefWithUser } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()()({
+    const { $href: $hrefWithUser } = defineTypedHrefWithNuqs.routes<Routes, RouteParamsMap>().nuqs({
       "/users/[id]": { tab: parseAsString },
     });
 
@@ -118,7 +125,7 @@ describe("dynamic segments work with nuqs searchParams", () => {
 });
 
 describe("withDefault pattern", () => {
-  const { $href: $hrefWD } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()()({
+  const { $href: $hrefWD } = defineTypedHrefWithNuqs.routes<Routes, RouteParamsMap>().nuqs({
     "/search": {
       q: parseAsString.withDefault(""),
       page: parseAsInteger.withDefault(1),
@@ -140,9 +147,12 @@ describe("withDefault pattern", () => {
   });
 
   test("skips undefined values for withDefault params", () => {
-    expect($hrefWD({ route: "/search", searchParams: { q: "hello", page: undefined } })).toBe(
-      "/search?q=hello",
-    );
+    expect(
+      $hrefWD({
+        route: "/search",
+        searchParams: { q: "hello", page: undefined },
+      }),
+    ).toBe("/search?q=hello");
   });
 
   test("omits param when value equals default", () => {
@@ -163,7 +173,7 @@ describe("withDefault pattern", () => {
 
 describe("withDefault with dynamic segments", () => {
   test("resolves route params and adds withDefault searchParams", () => {
-    const { $href: $hrefUserWD } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()()({
+    const { $href: $hrefUserWD } = defineTypedHrefWithNuqs.routes<Routes, RouteParamsMap>().nuqs({
       "/users/[id]": { tab: parseAsString.withDefault("profile") },
     });
 
@@ -177,13 +187,14 @@ describe("withDefault with dynamic segments", () => {
   });
 });
 
-describe("requiredSearchParams option", () => {
+describe(".withOptions({ requiredSearchParams: true }) method", () => {
   // q: no withDefault → required, page: withDefault → optional
-  const { $href: $hrefReq } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({
-    requiredSearchParams: true,
-  })({
-    "/search": { q: parseAsString, page: parseAsInteger.withDefault(1) },
-  });
+  const { $href: $hrefReq } = defineTypedHrefWithNuqs
+    .routes<Routes, RouteParamsMap>()
+    .withOptions({ requiredSearchParams: true })
+    .nuqs({
+      "/search": { q: parseAsString, page: parseAsInteger.withDefault(1) },
+    });
 
   test("accepts required field only (withDefault field omitted)", () => {
     expect($hrefReq({ route: "/search", searchParams: { q: "hello" } })).toBe("/search?q=hello");
@@ -205,12 +216,20 @@ describe("requiredSearchParams option", () => {
   });
 
   test("rejects missing searchParams object (type error)", () => {
-    // @ts-expect-error: searchParams is required when requiredSearchParams: true and parsers are defined
+    // @ts-expect-error: searchParams is required when .withOptions({ requiredSearchParams: true }) and parsers are defined
     $hrefReq({ route: "/search" });
   });
 
   test("rejects missing required field (type error)", () => {
     // @ts-expect-error: q has no withDefault, so it is required
     $hrefReq({ route: "/search", searchParams: { page: 2 } });
+  });
+});
+
+describe("entry API surface", () => {
+  test("routes() is the only entry point", () => {
+    expectTypeOf(defineTypedHrefWithNuqs).toHaveProperty("routes");
+    expectTypeOf(defineTypedHrefWithNuqs).not.toHaveProperty("nuqs");
+    expectTypeOf(defineTypedHrefWithNuqs).not.toHaveProperty("withOptions");
   });
 });

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -1,7 +1,8 @@
 import type { inferParserType, SingleParserBuilder } from "nuqs";
 import { createSerializer } from "nuqs/server";
 
-import { generatePath } from "./common/generatePath";
+import { resolveRoutePath } from "./common/resolveRoutePath";
+import type { RouteIdentityFor } from "./common/types";
 
 type AnyParserBuilder = SingleParserBuilder<any>;
 
@@ -51,11 +52,6 @@ export type NuqsBuilderOptions = {
   requiredSearchParams?: boolean;
 };
 
-type RouteHasParams<
-  T extends string,
-  RouteParamsMap extends Record<string, Record<string, unknown>>,
-> = RouteParamsMap[T] extends Record<string, never> ? false : true;
-
 type SearchParamsFor<
   T extends string,
   NuqsMap extends NuqsParsersMap<string>,
@@ -86,12 +82,8 @@ type PathOptionsFor<
   RouteParamsMap extends Record<Routes, Record<string, unknown>>,
   NuqsMap extends NuqsParsersMap<Routes>,
   Options extends NuqsBuilderOptions,
-> = T extends Routes
-  ? (RouteHasParams<T, RouteParamsMap> extends true
-      ? { route: T; routeParams: RouteParamsMap[T] }
-      : { route: T }) &
-      SearchParamsOptions<T, NuqsMap, Options> & { hash?: string }
-  : never;
+> = RouteIdentityFor<T, Routes, RouteParamsMap> &
+  SearchParamsOptions<T, NuqsMap, Options> & { hash?: string };
 
 type WithRoutes<
   Routes extends string,
@@ -124,30 +116,31 @@ function createWithRoutes<
 >(): WithRoutes<Routes, RouteParamsMap, Options> {
   return {
     // `_opts` is used only at the type level to capture `NewOptions`.
-    // Calling `.withOptions()` again overwrites the previous options.
     withOptions<NewOptions extends NuqsBuilderOptions>(_opts: NewOptions) {
       return createWithRoutes<Routes, RouteParamsMap, NewOptions>();
     },
     nuqs<NuqsMap extends NuqsParsersMap<Routes>>(nuqsMap: NuqsMap) {
+      // Precompute one serializer per route so `$href` doesn't rebuild it on each call.
+      type Serializer = (values: Record<string, unknown>) => string;
+      const serializers: Record<string, Serializer> = {};
+      for (const route in nuqsMap) {
+        const parsers = (nuqsMap as NuqsParsersMap<string>)[route];
+        if (parsers) serializers[route] = createSerializer(parsers) as Serializer;
+      }
+
       function $href<T extends Routes>(
         options: PathOptionsFor<T, Routes, RouteParamsMap, NuqsMap, Options>,
       ): string {
-        const path =
-          "routeParams" in options
-            ? generatePath(
-                options.route,
-                options.routeParams as Record<string, string | string[] | undefined>,
-              )
-            : options.route;
+        const path = resolveRoutePath(
+          options as { route: T; routeParams?: Record<string, string | string[] | undefined> },
+        );
 
-        const routeParsers = (nuqsMap as NuqsParsersMap<string>)[options.route];
+        const serializer = serializers[options.route];
         let search = "";
 
         if (options.searchParams != null) {
-          if (routeParsers) {
-            search = createSerializer(routeParsers)(
-              options.searchParams as Record<string, unknown>,
-            );
+          if (serializer) {
+            search = serializer(options.searchParams as Record<string, unknown>);
           } else {
             const sp = new URLSearchParams(
               options.searchParams as ConstructorParameters<typeof URLSearchParams>[0],

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -13,7 +13,7 @@ type ParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
   [K in keyof Parsers]?: inferParserType<Parsers[K]>;
 };
 
-// Fields whose inferred type includes null (no withDefault) are required; others (withDefault) are optional.
+// null extends inferParserType<T> means no .withDefault() → required field
 type RequiredParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
   [K in keyof Parsers as null extends inferParserType<Parsers[K]> ? K : never]: inferParserType<
     Parsers[K]
@@ -24,7 +24,7 @@ type RequiredParserValues<Parsers extends Record<string, AnyParserBuilder>> = {
   >;
 };
 
-export type DefineTypedHrefWithNuqsOptions = {
+export type NuqsBuilderOptions = {
   /**
    * When `true`, `searchParams` becomes required on routes that have nuqs parsers defined.
    *
@@ -34,12 +34,15 @@ export type DefineTypedHrefWithNuqsOptions = {
    * @default false
    *
    * @example
-   * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({ requiredSearchParams: true })({
-   *   "/search": {
-   *     q: parseAsString,                    // required (no withDefault)
-   *     page: parseAsInteger.withDefault(1), // optional (has withDefault)
-   *   },
-   * });
+   * const { $href } = defineTypedHrefWithNuqs
+   *   .routes<Routes, RouteParamsMap>()
+   *   .withOptions({ requiredSearchParams: true })
+   *   .nuqs({
+   *     "/search": {
+   *       q: parseAsString,                    // required (no withDefault)
+   *       page: parseAsInteger.withDefault(1), // optional (has withDefault)
+   *     },
+   *   });
    *
    * $href({ route: "/search", searchParams: { q: "hello" } })          // OK
    * $href({ route: "/search" })                                         // Type error: searchParams is required
@@ -56,7 +59,7 @@ type RouteHasParams<
 type SearchParamsFor<
   T extends string,
   NuqsMap extends NuqsParsersMap<string>,
-  Options extends DefineTypedHrefWithNuqsOptions,
+  Options extends NuqsBuilderOptions,
 > =
   NuqsMap[T] extends Record<string, AnyParserBuilder>
     ? Options["requiredSearchParams"] extends true
@@ -70,7 +73,7 @@ type RouteHasNuqsParsers<T extends string, NuqsMap extends NuqsParsersMap<string
 type SearchParamsOptions<
   T extends string,
   NuqsMap extends NuqsParsersMap<string>,
-  Options extends DefineTypedHrefWithNuqsOptions,
+  Options extends NuqsBuilderOptions,
 > = Options["requiredSearchParams"] extends true
   ? RouteHasNuqsParsers<T, NuqsMap> extends true
     ? { searchParams: SearchParamsFor<T, NuqsMap, Options> }
@@ -82,7 +85,7 @@ type PathOptionsFor<
   Routes extends string,
   RouteParamsMap extends Record<Routes, Record<string, unknown>>,
   NuqsMap extends NuqsParsersMap<Routes>,
-  Options extends DefineTypedHrefWithNuqsOptions,
+  Options extends NuqsBuilderOptions,
 > = T extends Routes
   ? (RouteHasParams<T, RouteParamsMap> extends true
       ? { route: T; routeParams: RouteParamsMap[T] }
@@ -90,56 +93,42 @@ type PathOptionsFor<
       SearchParamsOptions<T, NuqsMap, Options> & { hash?: string }
   : never;
 
-type InnerFn<
+type WithRoutes<
   Routes extends string,
   RouteParamsMap extends Record<Routes, Record<string, unknown>>,
-  Options extends DefineTypedHrefWithNuqsOptions,
-> = <NuqsMap extends NuqsParsersMap<Routes>>(
-  nuqsMap: NuqsMap,
-) => {
-  $href: <T extends Routes>(
-    options: PathOptionsFor<T, Routes, RouteParamsMap, NuqsMap, Options>,
-  ) => string;
+  Options extends NuqsBuilderOptions,
+> = {
+  withOptions: <NewOptions extends NuqsBuilderOptions>(
+    opts: NewOptions,
+  ) => WithRoutes<Routes, RouteParamsMap, NewOptions>;
+  nuqs: <NuqsMap extends NuqsParsersMap<Routes>>(
+    nuqsMap: NuqsMap,
+  ) => {
+    $href: <T extends Routes>(
+      options: PathOptionsFor<T, Routes, RouteParamsMap, NuqsMap, Options>,
+    ) => string;
+  };
 };
 
-/**
- * Type-safe href generator for Next.js App Router with nuqs integration.
- *
- * Routes that have nuqs parsers defined accept typed searchParams values.
- * Routes without parsers fall back to standard URLSearchParams input.
- *
- * Pass `{ requiredSearchParams: true }` in the second call to make `searchParams`
- * required on routes that have nuqs parsers defined.
- *
- * @example
- * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()()({
- *   "/search": { q: parseAsString, page: parseAsInteger },
- * });
- *
- * $href({ route: "/search", searchParams: { q: "hello", page: 2 } })
- * // => "/search?q=hello&page=2"
- *
- * @example requiredSearchParams
- * const { $href } = defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({ requiredSearchParams: true })({
- *   "/search": {
- *     q: parseAsString,                    // required (no withDefault)
- *     page: parseAsInteger.withDefault(1), // optional (has withDefault)
- *   },
- * });
- *
- * $href({ route: "/search", searchParams: { q: "hello" } })        // OK (page is optional)
- * $href({ route: "/search", searchParams: { q: "hello", page: 2 } }) // OK
- * $href({ route: "/search" })                                        // Type error: searchParams is required
- * $href({ route: "/search", searchParams: { page: 2 } })             // Type error: q is required
- */
-export function defineTypedHrefWithNuqs<
+type TypedHrefWithNuqsBuilder = {
+  routes: <
+    Routes extends string,
+    RouteParamsMap extends Record<Routes, Record<string, unknown>>,
+  >() => WithRoutes<Routes, RouteParamsMap, {}>;
+};
+
+function createWithRoutes<
   Routes extends string,
   RouteParamsMap extends Record<Routes, Record<string, unknown>>,
->() {
-  return function <const Options extends DefineTypedHrefWithNuqsOptions = {}>(
-    _options?: Options,
-  ): InnerFn<Routes, RouteParamsMap, Options> {
-    return function <NuqsMap extends NuqsParsersMap<Routes>>(nuqsMap: NuqsMap) {
+  Options extends NuqsBuilderOptions,
+>(): WithRoutes<Routes, RouteParamsMap, Options> {
+  return {
+    // `_opts` is used only at the type level to capture `NewOptions`.
+    // Calling `.withOptions()` again overwrites the previous options.
+    withOptions<NewOptions extends NuqsBuilderOptions>(_opts: NewOptions) {
+      return createWithRoutes<Routes, RouteParamsMap, NewOptions>();
+    },
+    nuqs<NuqsMap extends NuqsParsersMap<Routes>>(nuqsMap: NuqsMap) {
       function $href<T extends Routes>(
         options: PathOptionsFor<T, Routes, RouteParamsMap, NuqsMap, Options>,
       ): string {
@@ -172,6 +161,30 @@ export function defineTypedHrefWithNuqs<
       }
 
       return { $href };
-    };
+    },
   };
 }
+
+/**
+ * Builder for type-safe href generators for Next.js App Router with nuqs integration.
+ *
+ * Routes that have nuqs parsers defined accept typed searchParams values.
+ * Routes without parsers fall back to standard URLSearchParams input.
+ *
+ * Chaining: `.routes<R, M>()` is the only entry point. `.withOptions()` may
+ * be called before `.nuqs()`; calling `.withOptions()` more than once
+ * replaces the previously supplied options.
+ *
+ * @example
+ * const { $href } = defineTypedHrefWithNuqs
+ *   .routes<AppRoutes, AppRouteParamsMap>()
+ *   .nuqs({ "/search": { q: parseAsString, page: parseAsInteger } });
+ *
+ * $href({ route: "/search", searchParams: { q: "hello", page: 2 } })
+ * // => "/search?q=hello&page=2"
+ */
+export const defineTypedHrefWithNuqs: TypedHrefWithNuqsBuilder = {
+  routes() {
+    return createWithRoutes();
+  },
+};


### PR DESCRIPTION
## Summary

- `defineTypedHref` / `defineTypedHrefWithNuqs` をビルダーパターンに変更
- `.requiredSearchParams()` を `.withOptions()` に置き換え、将来のオプション追加に備えた設計に変更
- 実装はプロジェクトのコーディング規約（関数型 / `function` 宣言）に従い、`class` ではなく function + クロージャで構成

## 背景

#58 で3重カリー化（`()()()`）を用いた実装が提案されていたが、TypeScript の型引数部分適用の制限を回避するために tRPC が同じ問題を解決した方針（[trpc/trpc#2604](https://github.com/trpc/trpc/pull/2604)）を参考にビルダーパターンを採用した。

`initTRPC<{ context: Context }>()()` → `initTRPC.context<Context>().create()` に相当する流儀。

このPRではその方針を採用し、APIの読みやすさと一貫性を改善した。

## Breaking changes

### `defineTypedHref`

```ts
// before (#58)
defineTypedHref<Routes, RouteParamsMap>()

// after (this PR)
defineTypedHref.routes<Routes, RouteParamsMap>()
```

### `defineTypedHrefWithNuqs`

```ts
// before (#58)
defineTypedHrefWithNuqs<Routes, RouteParamsMap>()(nuqsMap)
defineTypedHrefWithNuqs<Routes, RouteParamsMap>()({ requiredSearchParams: true })(nuqsMap)

// after (this PR)
defineTypedHrefWithNuqs.routes<Routes, RouteParamsMap>().nuqs(nuqsMap)
defineTypedHrefWithNuqs
  .routes<Routes, RouteParamsMap>()
  .withOptions({ requiredSearchParams: true })
  .nuqs(nuqsMap)
```

`.routes()` が唯一のエントリーポイントで、`.withOptions()` と `.nuqs()` は型レベルで `.routes()` の後でしか呼べない。

## New feature: `.withOptions()`

共通オプションをビルダーチェーンに渡すメソッド。将来 zod / valibot モジュールが追加された際も同じ `withOptions` パターンを共有できる設計になっている。

`.withOptions()` を複数回呼んだ場合は、最後の呼び出しが以前のオプションを上書きする。

現在サポートするオプション（`NuqsBuilderOptions`）:

### `requiredSearchParams`

nuqs パーサーが定義されているルートで `searchParams` を必須にする。

- `.withDefault()` **なし** → フィールドが required（`null` は渡せる）
- `.withDefault()` **あり** → フィールドが optional

```ts
const { $href } = defineTypedHrefWithNuqs
  .routes<Routes, RouteParamsMap>()
  .withOptions({ requiredSearchParams: true })
  .nuqs({
    "/search": {
      q: parseAsString,                    // required (no withDefault)
      page: parseAsInteger.withDefault(1), // optional (has withDefault)
    },
  });

$href({ route: "/search", searchParams: { q: "hello" } }); // OK
$href({ route: "/search" });                                // Type error: searchParams is required
$href({ route: "/search", searchParams: { page: 2 } });    // Type error: q is required
```

## Internal improvements

- 共有型 `RouteHasParams` / `RouteIdentityFor` を `common/types.ts` に、route→path 変換ヘルパー `resolveRoutePath` を `common/resolveRoutePath.ts` に抽出し、`index.ts` / `nuqs.ts` 間の型・ロジック重複を解消
- `.nuqs()` 時点でルートごとに `createSerializer` を事前計算し、`$href` 呼び出し（各 `<Link>` レンダーごと）で再構築されないように改善

## Test plan

- [ ] `pnpm --filter @plainbrew/next-typed-href test run` — 48テスト全通過
- [ ] `defineTypedHref.routes<>()` で型エラーが出ないこと
- [ ] `defineTypedHrefWithNuqs.nuqs(...)` を `.routes()` を経由せず呼ぶと型エラーになること
- [ ] `.withOptions()` なしで `searchParams` が optional であること
- [ ] `.withOptions({ requiredSearchParams: true })` ありで nuqs パーサーがあるルートの `searchParams` が必須になること

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **破壊的な変更**
  * `defineTypedHref` と `defineTypedHrefWithNuqs` がメソッドチェーン形式（例: `.routes<...>().nuqs(...)` / `.routes<...>().withOptions(...).nuqs(...)`）へ移行しました。呼び出し方法の書き換えが必要です。
  * `withOptions({ requiredSearchParams: true })` と `withDefault()` により、検索パラメータの必須/任意挙動が制御可能になりました。
* **ドキュメント**
  * サンプルとリリース記載が新APIに合わせて更新されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
