### PR TITLE
test(next-typed-href): verify withOptions const modifier regression [review aid]

### DIFF
--- a/packages/next-typed-href/src/verify-withOptions-const.test.ts
+++ b/packages/next-typed-href/src/verify-withOptions-const.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression verification: withOptions<NewOptions> lacks `const` modifier.
+ *
+ * The old triple-curry used `<const Options extends ...>` which preserved literal
+ * types even when options are stored in a variable. The new withOptions() method
+ * uses `<NewOptions extends NuqsBuilderOptions>` without `const`, so TypeScript
+ * widens `true` → `boolean` for variable usage, breaking the `extends true` check
+ * in SearchParamsOptions.
+ */
+import { parseAsInteger, parseAsString } from "nuqs/server";
+import { describe, expectTypeOf, test } from "vitest";
+
+import { defineTypedHrefWithNuqs } from "./nuqs";
+
+type Routes = "/search" | "/";
+type RouteParamsMap = {
+  "/search": Record<string, never>;
+  "/": Record<string, never>;
+};
+
+describe("withOptions const modifier regression", () => {
+  test("inline literal: searchParams is required (this passes even without const)", () => {
+    const { $href } = defineTypedHrefWithNuqs
+      .routes<Routes, RouteParamsMap>()
+      .withOptions({ requiredSearchParams: true })
+      .nuqs({ "/search": { q: parseAsString } });
+
+    // searchParams must be required — calling without it should be a type error
+    // @ts-expect-error: searchParams is required
+    $href({ route: "/search" });
+
+    // This should be fine
+    expectTypeOf($href).parameter(0).toMatchTypeOf<{ searchParams: { q: string | null } }>();
+  });
+
+  test("variable opts: searchParams should still be required (FAILS without const modifier)", () => {
+    // When stored in a variable without `as const`, TypeScript widens:
+    //   { requiredSearchParams: true }  →  { requiredSearchParams: boolean }
+    // Without `const` on the type param, NewOptions = { requiredSearchParams: boolean },
+    // and `boolean extends true` is false → searchParams becomes optional.
+    const opts = { requiredSearchParams: true };
+
+    const { $href } = defineTypedHrefWithNuqs
+      .routes<Routes, RouteParamsMap>()
+      .withOptions(opts)
+      .nuqs({ "/search": { q: parseAsString, page: parseAsInteger } });
+
+    // This SHOULD be a type error (searchParams required) but is NOT,
+    // because without `const`, Options["requiredSearchParams"] widens to `boolean`,
+    // causing SearchParamsOptions to fall through to the optional branch.
+    //
+    // Remove the @ts-expect-error below to see the regression:
+    // if withOptions had `const NewOptions`, this line would be a type error.
+    //
+    // With the regression present: no type error here (searchParams is optional).
+    // With `const` fixed: this becomes a type error and the @ts-expect-error is needed.
+
+    // Check: is searchParams required or optional on the resulting $href?
+    type HrefParam = Parameters<typeof $href>[0];
+
+    // If `const` is missing, searchParams is OPTIONAL → HrefParam includes { route: "/search" } without searchParams
+    // If `const` is present, searchParams is REQUIRED → this type assertion would fail
+    expectTypeOf<{ route: "/search" }>().toMatchTypeOf<HrefParam>();
+    //                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    // This should NOT match if requiredSearchParams is truly enforced (searchParams would be required).
+    // If this expectation PASSES, the regression is confirmed: searchParams is optional when it shouldn't be.
+  });
+
+  test("variable opts with as const: searchParams is required (workaround)", () => {
+    const opts = { requiredSearchParams: true } as const;
+
+    const { $href } = defineTypedHrefWithNuqs
+      .routes<Routes, RouteParamsMap>()
+      .withOptions(opts)
+      .nuqs({ "/search": { q: parseAsString } });
+
+    // With `as const`, TypeScript preserves `true` literal → this IS a type error
+    // @ts-expect-error: searchParams is required when opts has requiredSearchParams: true (as const)
+    $href({ route: "/search" });
+  });
+});


### PR DESCRIPTION
## 目的

PR #61 (`experiment/nuqs-builder`) のレビュー用検証ブランチ。

`withOptions<NewOptions>` に `const` 修飾子がないことで、変数経由で渡した場合に `requiredSearchParams: true` が正しく型推論されないレグレッションを型テストで示す。

## 検証内容

`packages/next-typed-href/src/verify-withOptions-const.test.ts` に3ケースを追加：

| ケース | 期待する動作 | 実際の動作 |
|---|---|---|
| インラインリテラル `.withOptions({ requiredSearchParams: true })` | `searchParams` 必須 | ✅ 必須（正常） |
| 変数渡し `const opts = { requiredSearchParams: true }` | `searchParams` 必須 | ❌ 任意（レグレッション） |
| `as const` ワークアラウンド | `searchParams` 必須 | ✅ 必須（正常） |

## 原因

```ts
// 現状（WithRoutes 型定義）
withOptions: <NewOptions extends NuqsBuilderOptions>(
  opts: NewOptions,
) => ...

// const なしの場合、TypeScript が widen する:
// { requiredSearchParams: true } → { requiredSearchParams: boolean }
// → boolean extends true が false → searchParams が optional になる
```

## 修正案

```ts
// const を追加するだけ
withOptions: <const NewOptions extends NuqsBuilderOptions>(
  opts: NewOptions,
) => ...
```

型定義と実装の両方（`WithRoutes` 型 + `createWithRoutes` 内の `withOptions` メソッド）に追加が必要。
