### PR TITLE
feat(next-typed-href): require explicit type arguments on routes()

### DIFF
--- a/.changeset/require-explicit-routes-args.md
+++ b/.changeset/require-explicit-routes-args.md
@@ -1,0 +1,29 @@
+---
+"@plainbrew/next-typed-href": minor
+---
+
+feat: require explicit type arguments on `.routes()`
+
+`defineTypedHref.routes()` and `defineTypedHrefWithNuqs.routes()` now require
+explicit `<Routes, RouteParamsMap>` type arguments. Calling them without type
+arguments fails with a TypeScript error **at the call site** — previously
+`Routes` would silently widen to `string`, defeating the type-safety the
+library promises.
+
+```ts
+// ❌ Type error AT this line:
+//    "Expected 1 arguments, but got 0."
+//    Hover shows the missing parameter's name and message.
+defineTypedHref.routes();
+
+// ✅ OK
+defineTypedHref.routes<Routes, RouteParamsMap>();
+```
+
+The mechanism is a conditional rest parameter: when `string extends Routes`
+(i.e. no type argument was supplied), `routes` requires a single phantom
+argument whose name and type spell out the fix. When `Routes` is a proper
+literal union, the rest tuple is empty and the call is nullary as before.
+
+This is a type-level change only — no runtime behavior changes. Existing
+callers that already pass explicit type arguments are unaffected.

--- a/packages/next-typed-href/src/common/types.ts
+++ b/packages/next-typed-href/src/common/types.ts
@@ -69,3 +69,29 @@ export type RouteIdentityFor<
     ? { route: T; routeParams: RouteParamsMap[T] }
     : { route: T }
   : never;
+
+/**
+ * Resolves to a required rest-parameter when `.routes()` is called without
+ * explicit type arguments, forcing an "Expected 1 arguments, but got 0" error
+ * **on the `.routes()` call itself** — not on a downstream property access.
+ *
+ * `Routes` defaults to its constraint upper bound (`string`) when the caller
+ * does not supply a type argument; `string extends Routes` detects that and
+ * resolves to a single-element tuple. The parameter name spells out the fix
+ * and its type carries the explanatory message — both visible on hover.
+ * When `Routes` is a proper literal union the tuple is empty, so type-correct
+ * call sites stay nullary.
+ *
+ * @example
+ * // ❌ Type error AT the call site: "Expected 1 arguments, but got 0."
+ * //    Hover on .routes shows the required parameter's name and message.
+ * defineTypedHref.routes();
+ *
+ * // ✅ OK
+ * defineTypedHref.routes<"/", { "/": Record<string, never> }>();
+ */
+export type RequireExplicitRoutesArgs<Routes extends string> = string extends Routes
+  ? [
+      pass_Routes_and_RouteParamsMap_as_type_arguments: "routes<Routes, RouteParamsMap>() requires explicit type arguments",
+    ]
+  : [];

--- a/packages/next-typed-href/src/common/types.ts
+++ b/packages/next-typed-href/src/common/types.ts
@@ -74,17 +74,14 @@ export type RouteIdentityFor<
  * Forces an "Expected 1 arguments, but got 0" error **on `.routes()` itself**
  * — not on a downstream `.$href(...)` — when type arguments are omitted.
  *
- * The actual user-facing guidance comes from the rest-parameter name at the
- * call site (`...pass_Routes_and_RouteParamsMap_as_type_arguments`), which
- * tsc prints back in the diagnostic. The inner tuple-element type literal is
- * surfaced only via IDE hover.
+ * The rest-parameter name at the call site (`...typeArguments`) appears in
+ * the tsc diagnostic; the inner tuple-element type literal carries the full
+ * explanation and is surfaced via IDE hover.
  *
  * @example
  * defineTypedHref.routes();                           // ❌ TS2554 at this line
  * defineTypedHref.routes<Routes, RouteParamsMap>();   // ✅
  */
 export type RequireExplicitRoutesArgs<Routes extends string> = string extends Routes
-  ? [
-      pass_Routes_and_RouteParamsMap_as_type_arguments: "routes<Routes, RouteParamsMap>() requires explicit type arguments",
-    ]
+  ? [typeArguments: "routes<Routes, RouteParamsMap>() requires explicit type arguments"]
   : [];

--- a/packages/next-typed-href/src/common/types.ts
+++ b/packages/next-typed-href/src/common/types.ts
@@ -71,24 +71,17 @@ export type RouteIdentityFor<
   : never;
 
 /**
- * Resolves to a required rest-parameter when `.routes()` is called without
- * explicit type arguments, forcing an "Expected 1 arguments, but got 0" error
- * **on the `.routes()` call itself** — not on a downstream property access.
+ * Forces an "Expected 1 arguments, but got 0" error **on `.routes()` itself**
+ * — not on a downstream `.$href(...)` — when type arguments are omitted.
  *
- * `Routes` defaults to its constraint upper bound (`string`) when the caller
- * does not supply a type argument; `string extends Routes` detects that and
- * resolves to a single-element tuple. The parameter name spells out the fix
- * and its type carries the explanatory message — both visible on hover.
- * When `Routes` is a proper literal union the tuple is empty, so type-correct
- * call sites stay nullary.
+ * The actual user-facing guidance comes from the rest-parameter name at the
+ * call site (`...pass_Routes_and_RouteParamsMap_as_type_arguments`), which
+ * tsc prints back in the diagnostic. The inner tuple-element type literal is
+ * surfaced only via IDE hover.
  *
  * @example
- * // ❌ Type error AT the call site: "Expected 1 arguments, but got 0."
- * //    Hover on .routes shows the required parameter's name and message.
- * defineTypedHref.routes();
- *
- * // ✅ OK
- * defineTypedHref.routes<"/", { "/": Record<string, never> }>();
+ * defineTypedHref.routes();                           // ❌ TS2554 at this line
+ * defineTypedHref.routes<Routes, RouteParamsMap>();   // ✅
  */
 export type RequireExplicitRoutesArgs<Routes extends string> = string extends Routes
   ? [

--- a/packages/next-typed-href/src/index.test.ts
+++ b/packages/next-typed-href/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, expectTypeOf, test } from "vitest";
 
 import { defineTypedHref } from "./index";
 import type { TypedHref } from "./index";
@@ -66,9 +66,12 @@ describe("dynamic segments [slug]", () => {
 
 describe("catch-all segments [...slug]", () => {
   test("joins array with /", () => {
-    expect($href({ route: "/posts/[...slug]", routeParams: { slug: ["a", "b", "c"] } })).toBe(
-      "/posts/a/b/c",
-    );
+    expect(
+      $href({
+        route: "/posts/[...slug]",
+        routeParams: { slug: ["a", "b", "c"] },
+      }),
+    ).toBe("/posts/a/b/c");
   });
 
   test("encodes special characters in each segment", () => {
@@ -155,5 +158,16 @@ describe("searchParams formats", () => {
 
   test("no hash means no # in output", () => {
     expect($href({ route: "/" })).not.toContain("#");
+  });
+});
+
+describe("routes() requires explicit type arguments", () => {
+  test("calling routes() without type arguments is a type error at the call site", () => {
+    // @ts-expect-error: routes<Routes, RouteParamsMap>() requires explicit type arguments
+    defineTypedHref.routes();
+  });
+
+  test("routes<R, M>() with explicit type arguments compiles", () => {
+    expectTypeOf(defineTypedHref.routes<Routes, RouteParamsMap>()).toHaveProperty("$href");
   });
 });

--- a/packages/next-typed-href/src/index.ts
+++ b/packages/next-typed-href/src/index.ts
@@ -59,11 +59,8 @@ type WithTypedHrefRoutes<
 };
 
 type TypedHrefBuilder = {
-  routes: <
-    Routes extends string,
-    RouteParamsMap extends Record<Routes, Record<string, unknown>>,
-  >(
-    ...args: RequireExplicitRoutesArgs<Routes>
+  routes: <Routes extends string, RouteParamsMap extends Record<Routes, Record<string, unknown>>>(
+    ...pass_Routes_and_RouteParamsMap_as_type_arguments: RequireExplicitRoutesArgs<Routes>
   ) => WithTypedHrefRoutes<Routes, RouteParamsMap, {}>;
 };
 

--- a/packages/next-typed-href/src/index.ts
+++ b/packages/next-typed-href/src/index.ts
@@ -26,7 +26,13 @@
  *   .withOptions({ branded: true });
  */
 import { resolveRoutePath } from "./common/resolveRoutePath";
-import type { HrefOptions, HrefReturn, RouteIdentityFor, TypedHref } from "./common/types";
+import type {
+  HrefOptions,
+  HrefReturn,
+  RequireExplicitRoutesArgs,
+  RouteIdentityFor,
+  TypedHref,
+} from "./common/types";
 
 export type { TypedHref };
 
@@ -56,7 +62,9 @@ type TypedHrefBuilder = {
   routes: <
     Routes extends string,
     RouteParamsMap extends Record<Routes, Record<string, unknown>>,
-  >() => WithTypedHrefRoutes<Routes, RouteParamsMap, {}>;
+  >(
+    ...args: RequireExplicitRoutesArgs<Routes>
+  ) => WithTypedHrefRoutes<Routes, RouteParamsMap, {}>;
 };
 
 function createWithTypedHrefRoutes<

--- a/packages/next-typed-href/src/index.ts
+++ b/packages/next-typed-href/src/index.ts
@@ -60,7 +60,7 @@ type WithTypedHrefRoutes<
 
 type TypedHrefBuilder = {
   routes: <Routes extends string, RouteParamsMap extends Record<Routes, Record<string, unknown>>>(
-    ...pass_Routes_and_RouteParamsMap_as_type_arguments: RequireExplicitRoutesArgs<Routes>
+    ...typeArguments: RequireExplicitRoutesArgs<Routes>
   ) => WithTypedHrefRoutes<Routes, RouteParamsMap, {}>;
 };
 

--- a/packages/next-typed-href/src/nuqs.test.ts
+++ b/packages/next-typed-href/src/nuqs.test.ts
@@ -258,4 +258,16 @@ describe("entry API surface", () => {
     expectTypeOf(defineTypedHrefWithNuqs).not.toHaveProperty("nuqs");
     expectTypeOf(defineTypedHrefWithNuqs).not.toHaveProperty("withOptions");
   });
+
+  test("calling routes() without type arguments is a type error at the call site", () => {
+    // @ts-expect-error: routes<Routes, RouteParamsMap>() requires explicit type arguments
+    defineTypedHrefWithNuqs.routes();
+  });
+
+  test("routes<R, M>() with explicit type arguments returns the builder", () => {
+    expectTypeOf(defineTypedHrefWithNuqs.routes<Routes, RouteParamsMap>()).toHaveProperty("nuqs");
+    expectTypeOf(defineTypedHrefWithNuqs.routes<Routes, RouteParamsMap>()).toHaveProperty(
+      "withOptions",
+    );
+  });
 });

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -136,7 +136,7 @@ type WithRoutes<
 
 type TypedHrefWithNuqsBuilder = {
   routes: <Routes extends string, RouteParamsMap extends Record<Routes, Record<string, unknown>>>(
-    ...pass_Routes_and_RouteParamsMap_as_type_arguments: RequireExplicitRoutesArgs<Routes>
+    ...typeArguments: RequireExplicitRoutesArgs<Routes>
   ) => WithRoutes<Routes, RouteParamsMap, {}>;
 };
 
@@ -163,7 +163,10 @@ function createWithRoutes<
         options: PathOptionsFor<T, Routes, RouteParamsMap, NuqsMap, Options>,
       ): HrefReturn<Options> {
         const path = resolveRoutePath(
-          options as { route: T; routeParams?: Record<string, string | string[] | undefined> },
+          options as {
+            route: T;
+            routeParams?: Record<string, string | string[] | undefined>;
+          },
         );
 
         const serializer = serializers[options.route];

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -2,7 +2,12 @@ import type { inferParserType, SingleParserBuilder } from "nuqs";
 import { createSerializer } from "nuqs/server";
 
 import { resolveRoutePath } from "./common/resolveRoutePath";
-import type { HrefReturn, RouteIdentityFor, TypedHref } from "./common/types";
+import type {
+  HrefReturn,
+  RequireExplicitRoutesArgs,
+  RouteIdentityFor,
+  TypedHref,
+} from "./common/types";
 
 export type { TypedHref };
 
@@ -130,10 +135,9 @@ type WithRoutes<
 };
 
 type TypedHrefWithNuqsBuilder = {
-  routes: <
-    Routes extends string,
-    RouteParamsMap extends Record<Routes, Record<string, unknown>>,
-  >() => WithRoutes<Routes, RouteParamsMap, {}>;
+  routes: <Routes extends string, RouteParamsMap extends Record<Routes, Record<string, unknown>>>(
+    ...args: RequireExplicitRoutesArgs<Routes>
+  ) => WithRoutes<Routes, RouteParamsMap, {}>;
 };
 
 function createWithRoutes<

--- a/packages/next-typed-href/src/nuqs.ts
+++ b/packages/next-typed-href/src/nuqs.ts
@@ -136,7 +136,7 @@ type WithRoutes<
 
 type TypedHrefWithNuqsBuilder = {
   routes: <Routes extends string, RouteParamsMap extends Record<Routes, Record<string, unknown>>>(
-    ...args: RequireExplicitRoutesArgs<Routes>
+    ...pass_Routes_and_RouteParamsMap_as_type_arguments: RequireExplicitRoutesArgs<Routes>
   ) => WithRoutes<Routes, RouteParamsMap, {}>;
 };
 

--- a/packages/next-typed-href/src/routes-error-message.test.ts
+++ b/packages/next-typed-href/src/routes-error-message.test.ts
@@ -56,9 +56,7 @@ describe("routes() type-argument guidance surfaces in TS error output", () => {
   ])("$name.routes() error mentions the guidance parameter name", ({ source }) => {
     const output = compileSnippet(source);
     expect(output).toContain("TS2554");
-    expect(output).toContain(
-      "Arguments for the rest parameter 'pass_Routes_and_RouteParamsMap_as_type_arguments'",
-    );
+    expect(output).toContain("Arguments for the rest parameter 'typeArguments'");
   });
 
   test("defineTypedHref.routes<R, M>() with explicit args produces no error", () => {

--- a/packages/next-typed-href/src/routes-error-message.test.ts
+++ b/packages/next-typed-href/src/routes-error-message.test.ts
@@ -1,0 +1,75 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+import { describe, expect, test } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const VIRTUAL_FILE = resolve(here, "__virtual__check__.ts");
+
+function compileSnippet(source: string): string {
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2019,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    strict: true,
+    noEmit: true,
+    skipLibCheck: true,
+    esModuleInterop: true,
+    lib: ["lib.es2019.d.ts", "lib.dom.d.ts"],
+    types: [],
+  };
+  const host = ts.createCompilerHost(compilerOptions, true);
+  const originalGetSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, languageVersion, onError, shouldCreate) => {
+    if (name === VIRTUAL_FILE) {
+      return ts.createSourceFile(name, source, languageVersion, true);
+    }
+    return originalGetSourceFile(name, languageVersion, onError, shouldCreate);
+  };
+  host.fileExists = (name) => name === VIRTUAL_FILE || ts.sys.fileExists(name);
+  host.readFile = (name) => (name === VIRTUAL_FILE ? source : ts.sys.readFile(name));
+
+  const program = ts.createProgram([VIRTUAL_FILE], compilerOptions, host);
+  const diagnostics = ts.getPreEmitDiagnostics(program);
+  return ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+    getCurrentDirectory: () => here,
+    getCanonicalFileName: (f) => f,
+    getNewLine: () => "\n",
+  });
+}
+
+describe("routes() type-argument guidance surfaces in TS error output", () => {
+  test("defineTypedHref.routes() error mentions the guidance parameter name", () => {
+    const output = compileSnippet(`
+      import { defineTypedHref } from "./index";
+      defineTypedHref.routes();
+    `);
+    expect(output).toContain("TS2554");
+    expect(output).toContain(
+      "Arguments for the rest parameter 'pass_Routes_and_RouteParamsMap_as_type_arguments'",
+    );
+  });
+
+  test("defineTypedHrefWithNuqs.routes() error mentions the guidance parameter name", () => {
+    const output = compileSnippet(`
+      import { defineTypedHrefWithNuqs } from "./nuqs";
+      defineTypedHrefWithNuqs.routes();
+    `);
+    expect(output).toContain("TS2554");
+    expect(output).toContain(
+      "Arguments for the rest parameter 'pass_Routes_and_RouteParamsMap_as_type_arguments'",
+    );
+  });
+
+  test("defineTypedHref.routes<R, M>() with explicit args produces no error", () => {
+    const output = compileSnippet(`
+      import { defineTypedHref } from "./index";
+      type R = "/";
+      type M = { "/": Record<string, never> };
+      defineTypedHref.routes<R, M>();
+    `);
+    expect(output).toBe("");
+  });
+});

--- a/packages/next-typed-href/src/routes-error-message.test.ts
+++ b/packages/next-typed-href/src/routes-error-message.test.ts
@@ -5,8 +5,7 @@ import ts from "typescript";
 import { describe, expect, test } from "vitest";
 
 const here = dirname(fileURLToPath(import.meta.url));
-
-const VIRTUAL_FILE = resolve(here, "__virtual__check__.ts");
+const virtualFile = resolve(here, "snippet.ts");
 
 function compileSnippet(source: string): string {
   const compilerOptions: ts.CompilerOptions = {
@@ -17,21 +16,19 @@ function compileSnippet(source: string): string {
     noEmit: true,
     skipLibCheck: true,
     esModuleInterop: true,
-    lib: ["lib.es2019.d.ts", "lib.dom.d.ts"],
+    lib: ["lib.es2019.d.ts", "lib.webworker.d.ts"],
     types: [],
   };
   const host = ts.createCompilerHost(compilerOptions, true);
   const originalGetSourceFile = host.getSourceFile.bind(host);
   host.getSourceFile = (name, languageVersion, onError, shouldCreate) => {
-    if (name === VIRTUAL_FILE) {
+    if (name === virtualFile) {
       return ts.createSourceFile(name, source, languageVersion, true);
     }
     return originalGetSourceFile(name, languageVersion, onError, shouldCreate);
   };
-  host.fileExists = (name) => name === VIRTUAL_FILE || ts.sys.fileExists(name);
-  host.readFile = (name) => (name === VIRTUAL_FILE ? source : ts.sys.readFile(name));
 
-  const program = ts.createProgram([VIRTUAL_FILE], compilerOptions, host);
+  const program = ts.createProgram([virtualFile], compilerOptions, host);
   const diagnostics = ts.getPreEmitDiagnostics(program);
   return ts.formatDiagnosticsWithColorAndContext(diagnostics, {
     getCurrentDirectory: () => here,
@@ -41,22 +38,23 @@ function compileSnippet(source: string): string {
 }
 
 describe("routes() type-argument guidance surfaces in TS error output", () => {
-  test("defineTypedHref.routes() error mentions the guidance parameter name", () => {
-    const output = compileSnippet(`
-      import { defineTypedHref } from "./index";
-      defineTypedHref.routes();
-    `);
-    expect(output).toContain("TS2554");
-    expect(output).toContain(
-      "Arguments for the rest parameter 'pass_Routes_and_RouteParamsMap_as_type_arguments'",
-    );
-  });
-
-  test("defineTypedHrefWithNuqs.routes() error mentions the guidance parameter name", () => {
-    const output = compileSnippet(`
-      import { defineTypedHrefWithNuqs } from "./nuqs";
-      defineTypedHrefWithNuqs.routes();
-    `);
+  test.each([
+    {
+      name: "defineTypedHref",
+      source: `
+        import { defineTypedHref } from "./index";
+        defineTypedHref.routes();
+      `,
+    },
+    {
+      name: "defineTypedHrefWithNuqs",
+      source: `
+        import { defineTypedHrefWithNuqs } from "./nuqs";
+        defineTypedHrefWithNuqs.routes();
+      `,
+    },
+  ])("$name.routes() error mentions the guidance parameter name", ({ source }) => {
+    const output = compileSnippet(source);
     expect(output).toContain("TS2554");
     expect(output).toContain(
       "Arguments for the rest parameter 'pass_Routes_and_RouteParamsMap_as_type_arguments'",


### PR DESCRIPTION
## Summary

- `defineTypedHref.routes()` / `defineTypedHrefWithNuqs.routes()` を型引数なしで呼べないように変更
- エラーは **`.routes()` 呼び出し行自体** に出る (downstream の `.$href(...)` ではなく)
- 型レベルのみの変更 — ランタイム挙動は変わらない

## 背景

`.routes()` には型引数 `<Routes, RouteParamsMap>` が必要だが、省略しても TypeScript は `Routes` を制約上限 `string` として推論し、結果的に**型安全性が静かに失われていた**。

```ts
// before: 動くが型安全性ゼロ
const { $href } = defineTypedHref.routes();
$href({ route: "/anything-goes" });  // ✅ コンパイル通る (悪い意味で)
```

このPRで `.routes()` 行に直接エラーを出して早期検知する。

```ts
// after
defineTypedHref.routes();
// ❌ Expected 1 arguments, but got 0.   ← この行で停止
```

## 実装

`common/types.ts` に汎用ヘルパを追加:

```ts
export type RequireExplicitRoutesArgs<Routes extends string> = string extends Routes
  ? [
      pass_Routes_and_RouteParamsMap_as_type_arguments:
        "routes<Routes, RouteParamsMap>() requires explicit type arguments",
    ]
  : [];
```

`routes` のシグネチャに **conditional rest parameter** として適用:

```ts
type TypedHrefBuilder = {
  routes: <R extends string, M extends Record<R, ...>>(
    ...args: RequireExplicitRoutesArgs<R>
  ) => { $href: ... };
};
```

**仕組み:**
- ユーザーが `.routes<MyRoutes, MyMap>()` と書く → `Routes = MyRoutes` → rest tuple が `[]` → 引数 0 で OK
- ユーザーが `.routes()` と書く → `Routes = string` (制約上限) → rest tuple が `[phantom_arg]` → 引数 0 で **"Expected 1 arguments, but got 0"**

### なぜ rest parameter にしたか

最初は returns 型を error brand object に置き換える案 (`RequireExplicitRoutes<R, B>` → `{ __error: "..." }`) を試したが、以下の欠点があった:

- エラーが downstream の `.$href(...)` で発火するため、ユーザーは `.routes()` まで OK と誤解しがち
- ランタイム impl との型ズレを埋めるため `as unknown as TypedHrefBuilder["routes"]` のキャストが必要

rest parameter 案ではエラーが `.routes()` 行に出る上、ランタイム impl のシグネチャと型宣言が自然に一致するため**キャスト不要**。

### IDE 体験

ホバーすると以下が見える:

```
routes<R, M>(
  pass_Routes_and_RouteParamsMap_as_type_arguments:
    "routes<Routes, RouteParamsMap>() requires explicit type arguments"
): { $href: ... }
```

パラメータ**名**が指示、パラメータ**型** (string literal) がメッセージという役割分離。

## Breaking change?

技術的には型レベルの破壊的変更だが、**`.routes()` を型引数なしで呼んでいたコードは型安全性が崩れた状態**だったので、修正されるべきもの。changeset は `minor` 扱い。

## Test plan

- [ ] `pnpm --filter @plainbrew/next-typed-href test run` — 52テスト全通過
- [ ] `defineTypedHref.routes()` で `// @ts-expect-error` が成立すること (TS2554: Expected 1 arguments, but got 0)
- [ ] `defineTypedHref.routes<R, M>()` 明示時に通常の builder が返ること
- [ ] `defineTypedHrefWithNuqs` 側も同様の挙動

🤖 Generated with [Claude Code](https://claude.com/claude-code)
