### PR TITLE
docs(next-typed-href): update README for builder pattern API

### DIFF
--- a/packages/next-typed-href/README.md
+++ b/packages/next-typed-href/README.md
@@ -85,14 +85,12 @@ import type { AppRoutes, ParamsOf } from "@/../.next/types/routes";
 
 type AppRouteParamsMap = { [Route in AppRoutes]: ParamsOf<Route> };
 
-export const { $href } = defineTypedHrefWithNuqs
-  .routes<AppRoutes, AppRouteParamsMap>()
-  .nuqs({
-    "/search": {
-      q: parseAsString,
-      page: parseAsInteger,
-    },
-  });
+export const { $href } = defineTypedHrefWithNuqs.routes<AppRoutes, AppRouteParamsMap>().nuqs({
+  "/search": {
+    q: parseAsString,
+    page: parseAsInteger,
+  },
+});
 ```
 
 ### Usage
@@ -122,14 +120,12 @@ $href({ route: "/users/[id]", routeParams: { id: "42" }, searchParams: { tab: "p
 Parsers wrapped with `.withDefault()` make the type non-nullable and omit the key from the URL when the value equals the default:
 
 ```ts
-export const { $href } = defineTypedHrefWithNuqs
-  .routes<AppRoutes, AppRouteParamsMap>()
-  .nuqs({
-    "/search": {
-      q: parseAsString.withDefault(""),
-      page: parseAsInteger.withDefault(1),
-    },
-  });
+export const { $href } = defineTypedHrefWithNuqs.routes<AppRoutes, AppRouteParamsMap>().nuqs({
+  "/search": {
+    q: parseAsString.withDefault(""),
+    page: parseAsInteger.withDefault(1),
+  },
+});
 
 // Value differs from default → included
 $href({ route: "/search", searchParams: { q: "hello", page: 2 } });
@@ -161,14 +157,14 @@ export const { $href } = defineTypedHrefWithNuqs
   .withOptions({ requiredSearchParams: true })
   .nuqs({
     "/search": {
-      q: parseAsString,                    // required (no withDefault)
+      q: parseAsString, // required (no withDefault)
       page: parseAsInteger.withDefault(1), // optional (has withDefault)
     },
   });
 
-$href({ route: "/search", searchParams: { q: "hello" } });        // OK
-$href({ route: "/search" });                                       // Type error: searchParams is required
-$href({ route: "/search", searchParams: { page: 2 } });           // Type error: q is required
+$href({ route: "/search", searchParams: { q: "hello" } }); // OK
+$href({ route: "/search" }); // Type error: searchParams is required
+$href({ route: "/search", searchParams: { page: 2 } }); // Type error: q is required
 ```
 
 ### nuqs integration notes

--- a/packages/next-typed-href/README.md
+++ b/packages/next-typed-href/README.md
@@ -24,7 +24,7 @@ import type { AppRoutes, ParamsOf } from "@/../.next/types/routes";
 
 type AppRouteParamsMap = { [Route in AppRoutes]: ParamsOf<Route> };
 
-export const { $href } = defineTypedHref<AppRoutes, AppRouteParamsMap>();
+export const { $href } = defineTypedHref.routes<AppRoutes, AppRouteParamsMap>();
 ```
 
 ## Usage
@@ -85,12 +85,14 @@ import type { AppRoutes, ParamsOf } from "@/../.next/types/routes";
 
 type AppRouteParamsMap = { [Route in AppRoutes]: ParamsOf<Route> };
 
-export const { $href } = defineTypedHrefWithNuqs<AppRoutes, AppRouteParamsMap>()({
-  "/search": {
-    q: parseAsString,
-    page: parseAsInteger,
-  },
-});
+export const { $href } = defineTypedHrefWithNuqs
+  .routes<AppRoutes, AppRouteParamsMap>()
+  .nuqs({
+    "/search": {
+      q: parseAsString,
+      page: parseAsInteger,
+    },
+  });
 ```
 
 ### Usage
@@ -120,12 +122,14 @@ $href({ route: "/users/[id]", routeParams: { id: "42" }, searchParams: { tab: "p
 Parsers wrapped with `.withDefault()` make the type non-nullable and omit the key from the URL when the value equals the default:
 
 ```ts
-export const { $href } = defineTypedHrefWithNuqs<AppRoutes, AppRouteParamsMap>()({
-  "/search": {
-    q: parseAsString.withDefault(""),
-    page: parseAsInteger.withDefault(1),
-  },
-});
+export const { $href } = defineTypedHrefWithNuqs
+  .routes<AppRoutes, AppRouteParamsMap>()
+  .nuqs({
+    "/search": {
+      q: parseAsString.withDefault(""),
+      page: parseAsInteger.withDefault(1),
+    },
+  });
 
 // Value differs from default → included
 $href({ route: "/search", searchParams: { q: "hello", page: 2 } });
@@ -138,6 +142,33 @@ $href({ route: "/search", searchParams: { q: "hello", page: 1 } });
 // null is a type error for withDefault params
 $href({ route: "/search", searchParams: { q: null } });
 // => TypeError: Type 'null' is not assignable to type 'string | undefined'
+```
+
+### `withOptions` — shared builder options
+
+`.withOptions()` lets you configure behavior for the entire builder. Call it between `.routes()` and `.nuqs()`. Calling `.withOptions()` multiple times replaces the previous options.
+
+#### `requiredSearchParams`
+
+When `true`, `searchParams` becomes required on routes that have nuqs parsers defined:
+
+- Fields **without** `.withDefault()` → required (the type includes `null`, so `null` is accepted)
+- Fields **with** `.withDefault()` → optional
+
+```ts
+export const { $href } = defineTypedHrefWithNuqs
+  .routes<AppRoutes, AppRouteParamsMap>()
+  .withOptions({ requiredSearchParams: true })
+  .nuqs({
+    "/search": {
+      q: parseAsString,                    // required (no withDefault)
+      page: parseAsInteger.withDefault(1), // optional (has withDefault)
+    },
+  });
+
+$href({ route: "/search", searchParams: { q: "hello" } });        // OK
+$href({ route: "/search" });                                       // Type error: searchParams is required
+$href({ route: "/search", searchParams: { page: 2 } });           // Type error: q is required
 ```
 
 ### nuqs integration notes


### PR DESCRIPTION
## Summary

PR #61 のビルダーパターン変更に伴い、`packages/next-typed-href/README.md` を更新する。

- `defineTypedHref<R, M>()` → `defineTypedHref.routes<R, M>()`
- `defineTypedHrefWithNuqs<R, M>()(nuqsMap)` → `defineTypedHrefWithNuqs.routes<R, M>().nuqs(nuqsMap)`
- `withDefault` パターンのサンプルコードを新 API に合わせて更新
- 新機能 `.withOptions({ requiredSearchParams: true })` のセクションを追加

Closes #61 に伴うドキュメント対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)
