### PR TITLE
feat(vercel-basic-auth): add only-preview value to vercelEnvTarget

### DIFF
--- a/.changeset/vercel-basic-auth-only-preview.md
+++ b/.changeset/vercel-basic-auth-only-preview.md
@@ -1,0 +1,9 @@
+---
+"@plainbrew/vercel-basic-auth": minor
+---
+
+feat: add `only-preview` value to `vercelEnvTarget`
+
+`vercelEnvTarget: "only-preview"` applies Basic Auth only on Vercel preview
+deployments. Useful when you want to protect preview URLs while keeping
+production open.

--- a/packages/vercel-basic-auth/README.md
+++ b/packages/vercel-basic-auth/README.md
@@ -44,6 +44,7 @@ export default async function proxy(request: NextRequest) {
 | Value             | Behavior                                      |
 | ----------------- | --------------------------------------------- |
 | `only-production` | Apply Basic Auth to Vercel production only    |
+| `only-preview`    | Apply Basic Auth to Vercel preview only       |
 | `all`             | Apply Basic Auth to all Vercel environments   |
 | `disabled`        | Disable Basic Auth on all Vercel environments |
 

--- a/packages/vercel-basic-auth/src/index.test.ts
+++ b/packages/vercel-basic-auth/src/index.test.ts
@@ -73,6 +73,44 @@ describe("Vercel 環境 (VERCEL=1)", () => {
     expect(res?.status).toBe(401);
   });
 
+  test("vercelEnvTarget=only-preview で VERCEL_ENV=preview のとき認証チェックをする", () => {
+    process.env.VERCEL = "1";
+    process.env.VERCEL_ENV = "preview";
+    const req = makeRequest();
+    const res = basicAuth(req, {
+      username: USERNAME,
+      password: PASSWORD,
+      vercelEnvTarget: "only-preview",
+    });
+    expect(res?.status).toBe(401);
+  });
+
+  test("vercelEnvTarget=only-preview で VERCEL_ENV=production のとき null を返す", () => {
+    process.env.VERCEL = "1";
+    process.env.VERCEL_ENV = "production";
+    const req = makeRequest();
+    expect(
+      basicAuth(req, {
+        username: USERNAME,
+        password: PASSWORD,
+        vercelEnvTarget: "only-preview",
+      }),
+    ).toBeNull();
+  });
+
+  test("vercelEnvTarget=only-preview で VERCEL_ENV=preview のとき username が undefined でも null を返す", () => {
+    process.env.VERCEL = "1";
+    process.env.VERCEL_ENV = "production";
+    const req = makeRequest();
+    expect(
+      basicAuth(req, {
+        username: undefined,
+        password: undefined,
+        vercelEnvTarget: "only-preview",
+      }),
+    ).toBeNull();
+  });
+
   test("vercelEnvTarget=all で VERCEL_ENV=preview のとき認証チェックをする", () => {
     process.env.VERCEL = "1";
     process.env.VERCEL_ENV = "preview";

--- a/packages/vercel-basic-auth/src/index.test.ts
+++ b/packages/vercel-basic-auth/src/index.test.ts
@@ -98,7 +98,7 @@ describe("Vercel 環境 (VERCEL=1)", () => {
     ).toBeNull();
   });
 
-  test("vercelEnvTarget=only-preview で VERCEL_ENV=preview のとき username が undefined でも null を返す", () => {
+  test("vercelEnvTarget=only-preview で VERCEL_ENV=production のとき username が undefined でも null を返す", () => {
     process.env.VERCEL = "1";
     process.env.VERCEL_ENV = "production";
     const req = makeRequest();

--- a/packages/vercel-basic-auth/src/index.ts
+++ b/packages/vercel-basic-auth/src/index.ts
@@ -1,4 +1,4 @@
-export type VercelEnvTarget = "only-production" | "all" | "disabled";
+export type VercelEnvTarget = "only-production" | "only-preview" | "all" | "disabled";
 
 export type BasicAuthOptions = {
   username: string | undefined;
@@ -44,6 +44,9 @@ export function basicAuth(
       return null;
     }
     if (vercelEnvTarget === "only-production" && process.env.VERCEL_ENV !== "production") {
+      return null;
+    }
+    if (vercelEnvTarget === "only-preview" && process.env.VERCEL_ENV !== "preview") {
       return null;
     }
   }


### PR DESCRIPTION
## Summary

`@plainbrew/vercel-basic-auth` の `vercelEnvTarget` に `only-preview` を追加しました。Vercel の preview 環境のみ Basic 認証を適用したいケースで使えます。

| Value             | Behavior                                      |
| ----------------- | --------------------------------------------- |
| `only-production` | Vercel production のみ                        |
| `only-preview`    | Vercel preview のみ (**new**)                 |
| `all`             | Vercel の全環境                               |
| `disabled`        | Vercel 全環境で無効                           |

Closes [PC-274](https://linear.app/plainbrew/issue/PC-274/vercel-basic-auth-に-only-preview-option-を追加)

## Test plan

- [x] `pnpm --filter @plainbrew/vercel-basic-auth test:run` (27 passed)
- [x] `pnpm --filter @plainbrew/vercel-basic-auth type-check`
